### PR TITLE
Add version warning logic to doc pages

### DIFF
--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -16,13 +16,13 @@
 
     <div class="field has-addons">
       <p class="control">
-        <span class="button is-dark is-radiusless">
+        <span class="button is-small is-dark is-radiusless">
           <strong>{{ $version }}</strong>
         </span>
       </p>
       {{ if $isLatest }}
       <p class="control">
-        <span class="button is-success is-radiusless">
+        <span class="button is-small is-success is-radiusless">
           <strong>
             latest
           </strong>
@@ -30,7 +30,7 @@
       </p>
       {{ else if $latestExists }}
       <p class="control">
-        <a class="button is-warning is-radiusless" href="{{ $latestUrl }}">
+        <a class="button is-small is-warning is-radiusless" href="{{ $latestUrl }}">
           Click here for the latest version
         </a>
       </p>

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -1,4 +1,8 @@
-{{ $pathLength        := len (split .Path "/") }}
+{{ $version      := index (split .File.Path "/") 1 }}
+{{ $latest       := printf "v%s" site.Params.versions.latest }}
+{{ $isLatest     := eq $version $latest }}
+{{ $latestUrl    := replace .RelPermalink $version $latest }}
+{{ $latestExists := gt (len (where site.Pages ".RelPermalink" "eq" $latestUrl)) 0 }}
 <section class="hero is-primary">
   <div class="hero-body">
     <p class="title is-size-1 is-size-2-mobile has-text-weight-light{{ if .Params.description }} is-spaced{{ end }}">
@@ -10,10 +14,27 @@
     </p>
     {{ end }}
 
-    <div class="buttons are-small">
-      <a class="button">
-        Button
-      </a>
+    <div class="field has-addons">
+      <p class="control">
+        <span class="button is-dark is-radiusless">
+          <strong>{{ $version }}</strong>
+        </span>
+      </p>
+      {{ if $isLatest }}
+      <p class="control">
+        <span class="button is-success is-radiusless">
+          <strong>
+            latest
+          </strong>
+        </span>
+      </p>
+      {{ else if $latestExists }}
+      <p class="control">
+        <a class="button is-warning is-radiusless" href="{{ $latestUrl }}">
+          Click here for the latest version
+        </a>
+      </p>
+      {{ end }}
     </div>
   </div>
 </section>

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -9,5 +9,11 @@
       {{ . | markdownify }}
     </p>
     {{ end }}
+
+    <div class="buttons are-small">
+      <a class="button">
+        Button
+      </a>
+    </div>
   </div>
 </section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,6 @@ bulma-dashboard@^0.1.34:
   integrity sha512-X+suGy0faRKtp7nK78/1A6Vq6obnGOMaWT+QMHuS+MRiqVTt5iarsNdOyUYI720JeZeBxeJ3P6/PghJ9gAFd+w==
 
 bulma@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"
-  integrity sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ==
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.4.tgz#7e74512e9118d9799021339e67e365ee0ac4f3f9"
+  integrity sha512-krG2rP6eAX1WE0sf6O0SC/FUVSOBX4m1PBC2+GKLpb2pX0qanaDqcv9U2nu75egFrsHkI0zdWYuk/oGwoszVWg==


### PR DESCRIPTION
This PR addresses an issue mentioned in issue #9 regarding latest vs. older logic on pages.

For an example here's a latest page:

https://deploy-preview-29--etcd.netlify.com/docs/v3.3.12/metrics/

And the older counterpart:

https://deploy-preview-29--etcd.netlify.com/docs/v3.2.17/metrics/