### PR TITLE
Enable robots.txt and add template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ languageCode = "en-us"
 pygmentsCodeFences = true
 pygmentsStyle = "fruity"
 baseURL = "https://etcd.io"
+enableRobotsTxt = true
 ignoreFiles = [
   "content/docs/v*/README.md",
   "content/docs/v*/*/README.md",

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,1 +1,2 @@
+Sitemap: {{ site.BaseURL }}/sitemap.xml
 User-agent: *


### PR DESCRIPTION
I got a `Indexed, though blocked by robots.txt` warning from Google Search Console. This PR adds a `robots.txt` file that should address this issue.