### PR TITLE
Fix layout on Safari

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -63,6 +63,9 @@ $navbar-item-img-max-height: $navbar-height * 0.5
     margin: 0 auto
     figcaption
 
+// Safari-specific attribute
+.hero
+  display: -webkit-box
 
 .is-hero-logo
   +logo(60%, 30%)


### PR DESCRIPTION
Hi! This small fix helps showing the header properly on Safari.

Issue:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/18210256/72758106-22214c80-3bd2-11ea-97ca-36227d74ed86.png">