### PR TITLE
Nit: Update demo to use quoted curl command.

### DIFF
--- a/content/docs/v3.4.0/demo.md
+++ b/content/docs/v3.4.0/demo.md
@@ -57,7 +57,7 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 Or use our public discovery service:
 
 ```shell
-curl https://discovery.etcd.io/new?size=3
+curl 'https://discovery.etcd.io/new?size=3'
 https://discovery.etcd.io/a81b5818e67a6ea83e9d4daea5ecbc92
 
 # grab this token


### PR DESCRIPTION
On shells like zsh the '?' in URL gets interpreted without quotation, leading to: 

% curl https://discovery.etcd.io/new?size=3 
zsh: no matches found: https://discovery.etcd.io/new?size=3