### PR TITLE
Added a missing "/" for go etcd client url

### DIFF
--- a/content/docs/v3.4.0/integrations.md
+++ b/content/docs/v3.4.0/integrations.md
@@ -23,7 +23,7 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/clientv3) - the officially maintained Go client for v3
+- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
 - [etcd/client](https://github.com/etcd-io/etcd/blob/master/client) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.


### PR DESCRIPTION
Added a missing "/" for go etcd client url. Currently it results in 404