### PR TITLE
Documentation Content: Versioning (Fix multi-version navigation)

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -66,6 +66,22 @@ $colors: mergeColorMaps(("orange": ($orange, $white)), $colors)
     margin: 0 auto
     figcaption
 
+// Deprecation warning
+.deprecation-warning
+  padding: 20px
+  margin: 20px 0
+  background-color: #faf5b6
+  color: #000
+
+body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-documentation .deprecation-warning
+  border-radius: 3px
+
+body.td-home #deprecation-warning
+  max-width: 1000px
+  margin-top: 2.5rem
+  margin-left: auto
+  margin-right: auto
+
 // Safari-specific attribute
 .hero
   display: -webkit-box

--- a/config.toml
+++ b/config.toml
@@ -40,8 +40,8 @@ Latency from the etcd leader is the most important metric to track and the built
 unsafe = true
 
 [params.versions]
-latest = "3.4.0"
-all    = ["3.4.0", "3.3.13", "3.3.12", "3.2.17", "3.1.12", "2"]
+latest = "v3.4.0"
+all    = ["v3.4.0", "v3.3.13", "v3.3.12", "v3.2.17", "v3.1.12", "v2"]
 
 [params.logos]
 hero   = "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/horizontal/white/etcd-horizontal-white.png"

--- a/content/docs/v2/_index.md
+++ b/content/docs/v2/_index.md
@@ -1,5 +1,7 @@
 ---
 title: etcd version 2
+cascade:
+  version: v2
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/docs/v3.1.12/_index.md
+++ b/content/docs/v3.1.12/_index.md
@@ -1,5 +1,7 @@
 ---
 title: etcd version 3.1.12
+cascade:
+  version: v3.1.12
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/docs/v3.2.17/_index.md
+++ b/content/docs/v3.2.17/_index.md
@@ -1,5 +1,7 @@
 ---
 title: etcd version 3.2.17
+cascade:
+  version: v3.2.17
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/docs/v3.3.12/_index.md
+++ b/content/docs/v3.3.12/_index.md
@@ -1,5 +1,7 @@
 ---
 title: etcd version 3.3.12
+cascade:
+  version: v3.3.12
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/docs/v3.3.13/_index.md
+++ b/content/docs/v3.3.13/_index.md
@@ -1,3 +1,5 @@
 ---
 title: etcd version 3.3.13
+cascade:
+  version: v3.3.13
 ---

--- a/content/docs/v3.4.0/_index.md
+++ b/content/docs/v3.4.0/_index.md
@@ -1,5 +1,7 @@
 ---
 title: etcd version 3.4.0
+cascade:
+  version: v3.4.0
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/layouts/docs/section.en.html
+++ b/layouts/docs/section.en.html
@@ -12,6 +12,8 @@ etcd | {{ .Title }}
   <div class="dashboard-main is-scrollable">
     {{ partial "docs/hero.html" . }}
   
+    {{ partial "deprecation-warning.html" . }}
+
     <section class="section">
       <div class="content docs-content">
         {{ with .Content }}
@@ -19,6 +21,7 @@ etcd | {{ .Title }}
 
         <hr />
         {{ end }}
+
 
         {{ if and $isVersionMainPage .Sections }}
         <h4>

--- a/layouts/docs/single.en.html
+++ b/layouts/docs/single.en.html
@@ -10,6 +10,8 @@ etcd docs | {{ .Title }}
   <div class="dashboard-main is-scrollable">
     {{ partial "docs/hero.html" . }}
   
+    {{ partial "deprecation-warning.html" . }}
+
     {{ partial "docs/article.html" . }}
 
     {{ partial "footer.html" . }}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,4 +1,4 @@
 {{ $latest := site.Params.versions.latest }}
-/docs     /docs/v{{ $latest }}
-/docs/latest     /docs/v{{ $latest }}
-/docs/latest/*     /docs/v{{ $latest }}/:splat
+/docs     /docs/{{ $latest }}
+/docs/latest     /docs/{{ $latest }}
+/docs/latest/*     /docs/{{ $latest }}/:splat

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -1,0 +1,20 @@
+<!-- based on https://github.com/kubernetes/website/blob/master/layouts/partials/deprecation-warning.html -->
+
+{{ if ne site.Params.versions.latest .CurrentSection.Params.version }}
+
+{{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
+{{ $currentUrl := .Permalink }}
+{{ $new_version := printf "/%s/" site.Params.versions.latest }}
+
+<section class="section" id="deprecation-warning">
+  <div class="content deprecation-warning">
+    <h3>
+      You are viewing documentation for etcd version: {{ .Param "version" }}
+    </h3>
+    <p> etcd {{ .Param "version" }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see the latest release,
+    <a href="{{ replace $currentUrl $original_version $new_version | relURL }}">{{ site.Params.versions.latest }}</a>.
+    </p>
+  </div>
+</section>
+{{ end }}
+

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -1,5 +1,5 @@
 {{ $version      := index (split .File.Path "/") 1 }}
-{{ $latest       := printf "v%s" site.Params.versions.latest }}
+{{ $latest       := printf "%s" site.Params.versions.latest }}
 {{ $allVersions  := site.Params.versions.all }}
 {{ $versions     := (slice) }}
 {{ $here         := .RelPermalink }}
@@ -33,8 +33,8 @@
 
         <div class="level-item">
           <div class="buttons">
-            {{ range $versions }}
-            {{ $v := printf "v%s" . }}
+            {{ range .Site.Params.versions.all }}
+            {{ $v := printf "%s" . }}
             {{ $isLatest := eq $latest $v }}
             {{ $href := replace $here $version $v }}
             <a class="button is-primary is-outlined has-text-weight-bold" href="{{ $href }}">

--- a/layouts/partials/docs/nav-panel.html
+++ b/layouts/partials/docs/nav-panel.html
@@ -3,7 +3,6 @@
 {{ $editUrl    := printf "https://github.com/etcd-io/website/edit/master/content/%s" .File.Path }}
 {{ $latest     := site.Params.versions.latest }}
 {{ $ghUrl      := printf "https://github.com/etcd-io/etcd/releases/tag/v%s" $latest }}
-{{ $versions   := site.Params.versions.all }}
 {{ $version    := index (split .Path "/") 1 }}
 {{ $allDocs    := where site.Sections "Section" "docs" }}
 {{ $currentUrl := .RelPermalink }}
@@ -31,19 +30,22 @@
 
       <div class="dropdown-menu">
         <div class="dropdown-content">
-          {{ range $versions }}
-          {{ $v           := printf "v%s" . }}
-          {{ $latest      := printf "v%s" $latest }}
-          {{ $isLatest    := eq $v $latest }}
-          <a class="navbar-item" href="/docs/v{{ . }}">
-            {{ . }}
-            {{ if $isLatest }}
-            (<strong>latest</strong>)
-            {{ end }}
-          </a>
+          {{/* 
+            Version dropdown modified based on the work https://github.com/tbatard did on the velero site:
+            https://github.com/vmware-tanzu/velero/blob/main/site/layouts/docs/versions.html
+          */}}
+          {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
+          {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest | relURL }}
+          {{ $currentUrl := .Permalink }}
+
+          {{ range .Site.Params.versions.all }}
+            {{ $new_version := printf "/%s/" . }}
+            <a class="navbar-item" 
+               href="{{ replace $currentUrl $original_version $new_version | relURL }}">{{ . }}</a>
           {{ end }}
         </div>
       </div>
+
     </div>
   </div>
 

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -21,7 +21,7 @@
         Home
       </a>
 
-      <a class="navbar-item" href="/docs/v{{ $latest }}">
+      <a class="navbar-item" href="/docs/{{ $latest }}">
         Docs home
       </a>
 

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -17,7 +17,7 @@
       <br />
 
       <div class="buttons is-centered">
-        <a class="button is-primary is-inverted is-large is-radiusless" href="/docs/v{{ $latest }}">
+        <a class="button is-primary is-inverted is-medium is-radiusless" href="/docs/{{ $latest }}">
           <span class="icon">
             <i class="fas fa-info"></i>
           </span>

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -2,8 +2,8 @@
 <ul>
   {{ range $versions }}
   <li>
-    <a href="/docs/v{{ . }}">
-      v{{ . }}
+    <a href="/docs/{{ . }}">
+      {{ . }}
     </a>
   </li>
   {{ end }}


### PR DESCRIPTION
Updating version selector dropdown
* Allowing switching between historical versions of the same page

Removing hardcoded "v" from version code
* Potentially, not all versions will need to start with "v"

Updating hero.html
* correcting "Docs" button size

Deploy preview: https://deploy-preview-86--etcd.netlify.app/
Latest docs page: https://deploy-preview-86--etcd.netlify.app/docs/v3.4.0/
Sample deprecated page: https://deploy-preview-86--etcd.netlify.app/docs/v3.3.13/metrics/

fixes: https://github.com/etcd-io/website/issues/82