### PR TITLE
Fix 404 for grafana assets

### DIFF
--- a/content/docs/current/op-guide/monitoring.md
+++ b/content/docs/current/op-guide/monitoring.md
@@ -127,9 +127,9 @@ Then import the default [etcd dashboard template][template] and customize. For i
 
 Sample dashboard:
 
-![](./etcd-sample-grafana.png)
+![](../etcd-sample-grafana.png)
 
 
 [prometheus]: https://prometheus.io/
 [grafana]: http://grafana.org/
-[template]: ./grafana.json
+[template]: ../grafana.json


### PR DESCRIPTION
The relative path was not working on https://etcd.io/docs/current/op-guide/monitoring/#grafana

Edited online. Hoping netlify preview will ensure that the issue was fixed.