### PR TITLE
Fixed broken links to etcd/client variants on the integrations page

### DIFF
--- a/content/docs/current/integrations.md
+++ b/content/docs/current/integrations.md
@@ -29,8 +29,8 @@ The sections below list etcd client libraries by language.
 
 ### Go
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/clientv3) - the officially maintained Go client for v3
-- [etcd/client](https://github.com/etcd-io/etcd/blob/master/client) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 


### PR DESCRIPTION
These links were previously broken and returned 404's.