### PR TITLE
Render-link: whitespace fix

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,10 +1,16 @@
-{{ $link := .Destination }}
-{{ $isRemote := strings.HasPrefix $link "http" }}
-{{- if not $isRemote -}}
-{{ $url := urls.Parse .Destination }}
-{{- if $url.Path -}}
-{{ $fragment := "" }}
-{{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
-{{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}{{ end -}}
-{{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}</a>
+{{ $link := .Destination -}}
+{{ $isRemote := strings.HasPrefix $link "http" -}}
+{{ if not $isRemote -}}
+  {{ $url := urls.Parse .Destination -}}
+  {{ if $url.Path -}}
+    {{ $fragment := "" -}}
+    {{ with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+    {{ with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end -}}
+  {{ end -}}
+{{ end -}}
+<a href="{{ $link | safeURL }}"
+  {{- with .Title}} title="{{ . }}"{{ end -}}
+  {{- if $isRemote }} target="_blank"{{ end -}}
+>
+{{- .Text | safeHTML -}}
+</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -10,7 +10,7 @@
 {{ end -}}
 <a href="{{ $link | safeURL }}"
   {{- with .Title}} title="{{ . }}"{{ end -}}
-  {{- if $isRemote }} target="_blank"{{ end -}}
+  {{- if $isRemote }} target="_blank" rel="noopener"{{ end -}}
 >
 {{- .Text | safeHTML -}}
 </a>


### PR DESCRIPTION
- Closes #115
- I'm fixing this now because it is preventing me from proposing a solution to #114
- **Preview**: https://deploy-preview-116--etcd.netlify.app/docs/current/op-guide/configuration/#clustering-flags

Before:
> <img src="https://user-images.githubusercontent.com/4140793/111357973-32ab4680-8660-11eb-837b-b8904feca044.png" width=600>

After:
> <img src="https://user-images.githubusercontent.com/4140793/111361567-350f9f80-8664-11eb-9636-25c77cc8b075.png" width=600>

cc @nate-double-u @zacharysarah