### PR TITLE
Gitignore: ignore public even if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules/
 
 # Hugo-generated assets
-public/
+/public
 resources/
 
 # Link checker artifacts


### PR DESCRIPTION
This tweak allows us to have a symlink for `public`, which is useful when contributors use another repo to hold the generated site files for the purpose of identifying site changes.

cc @spzala @nate-double-u 