### PR TITLE
Removing links from link-only section headings

### DIFF
--- a/content/docs/v3.3.12/learning/client-feature-matrix.md
+++ b/content/docs/v3.3.12/learning/client-feature-matrix.md
@@ -20,8 +20,8 @@ Load balancer |	Round-Robin | ·
 `MaxCallRecvMsgSize` | Yes | .
 `RejectOldCluster` | Yes | .
 
-## [KV](https://godoc.org/go.etcd.io/etcd/clientv3#KV)
-
+## KV
+https://godoc.org/go.etcd.io/etcd/clientv3#KV
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -32,7 +32,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Do(Op)` | Yes | .
 `Txn` | Yes | .
 
-## [Lease](https://godoc.org/go.etcd.io/etcd/clientv3#Lease)
+## Lease
+https://godoc.org/go.etcd.io/etcd/clientv3#Lease
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -43,14 +44,16 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `KeepAlive` | Yes | .
 `KeepAliveOnce` | Yes | .
 
-## [Watcher](https://godoc.org/go.etcd.io/etcd/clientv3#Watcher)
+## Watcher
+https://godoc.org/go.etcd.io/etcd/clientv3#Watcher
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `Watch` | Yes | Yes
 `RequestProgress` | Yes | .
 
-## [Cluster](https://godoc.org/go.etcd.io/etcd/clientv3#Cluster)
+## Cluster
+https://godoc.org/go.etcd.io/etcd/clientv3#Cluster
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -59,7 +62,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `MemberRemove` | Yes | Yes
 `MemberUpdate` | Yes | Yes
 
-## [Maintenance](https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance)
+## Maintenance
+https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -71,7 +75,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Snapshot` | Yes | ·
 `MoveLeader` | Yes | ·
 
-## [Auth](https://godoc.org/go.etcd.io/etcd/clientv3#Auth)
+## Auth
+https://godoc.org/go.etcd.io/etcd/clientv3#Auth
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -91,14 +96,16 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `RoleRevokePermission` | Yes | .
 `RoleDelete` | Yes | .
 
-## [clientv3util](https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util)
+## clientv3util
+https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `KeyExists` | Yes | No
 `KeyMissing` | Yes | No
 
-## [Concurrency](https://godoc.org/go.etcd.io/etcd/clientv3/concurrency)
+## Concurrency
+https://godoc.org/go.etcd.io/etcd/clientv3/concurrency
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -115,20 +122,23 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `STM Rev` | Yes | No
 `STM Del` | Yes | No
 
-## [Leasing](https://godoc.org/go.etcd.io/etcd/clientv3/leasing)
+## Leasing
+https://godoc.org/go.etcd.io/etcd/clientv3/leasing
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `NewKV(Client, prefix)` | Yes | No
 
-## [Mirror](https://godoc.org/go.etcd.io/etcd/clientv3/mirror)
+## Mirror
+https://godoc.org/go.etcd.io/etcd/clientv3/mirror
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `SyncBase` | Yes | No
 `SyncUpdates` | Yes | No
 
-## [Namespace](https://godoc.org/go.etcd.io/etcd/clientv3/namespace)
+## Namespace
+https://godoc.org/go.etcd.io/etcd/clientv3/namespace
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -136,19 +146,22 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Lease` | Yes | No
 `Watcher` | Yes | No
 
-## [Naming](https://godoc.org/go.etcd.io/etcd/clientv3/naming)
+## Naming
+https://godoc.org/go.etcd.io/etcd/clientv3/naming
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `GRPCResolver` | Yes | No
 
-## [Ordering](https://godoc.org/go.etcd.io/etcd/clientv3/ordering)
+## Ordering
+https://godoc.org/go.etcd.io/etcd/clientv3/ordering
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `KV` | Yes | No
 
-## [Snapshot](https://godoc.org/go.etcd.io/etcd/clientv3/snapshot)
+## Snapshot
+https://godoc.org/go.etcd.io/etcd/clientv3/snapshot
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------

--- a/content/docs/v3.3.13/learning/client-feature-matrix.md
+++ b/content/docs/v3.3.13/learning/client-feature-matrix.md
@@ -20,7 +20,8 @@ Load balancer |	Round-Robin | ·
 `MaxCallRecvMsgSize` | Yes | .
 `RejectOldCluster` | Yes | .
 
-## [KV](https://godoc.org/go.etcd.io/etcd/clientv3#KV)
+## KV
+https://godoc.org/go.etcd.io/etcd/clientv3#KV
 
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
@@ -32,7 +33,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Do(Op)` | Yes | .
 `Txn` | Yes | .
 
-## [Lease](https://godoc.org/go.etcd.io/etcd/clientv3#Lease)
+## Lease
+https://godoc.org/go.etcd.io/etcd/clientv3#Lease
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -43,14 +45,16 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `KeepAlive` | Yes | .
 `KeepAliveOnce` | Yes | .
 
-## [Watcher](https://godoc.org/go.etcd.io/etcd/clientv3#Watcher)
+## Watcher
+https://godoc.org/go.etcd.io/etcd/clientv3#Watcher
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `Watch` | Yes | Yes
 `RequestProgress` | Yes | .
 
-## [Cluster](https://godoc.org/go.etcd.io/etcd/clientv3#Cluster)
+## Cluster
+https://godoc.org/go.etcd.io/etcd/clientv3#Cluster
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -59,7 +63,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `MemberRemove` | Yes | Yes
 `MemberUpdate` | Yes | Yes
 
-## [Maintenance](https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance)
+## Maintenance
+https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -71,7 +76,8 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Snapshot` | Yes | ·
 `MoveLeader` | Yes | ·
 
-## [Auth](https://godoc.org/go.etcd.io/etcd/clientv3#Auth)
+## Auth
+https://godoc.org/go.etcd.io/etcd/clientv3#Auth
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -91,14 +97,16 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `RoleRevokePermission` | Yes | .
 `RoleDelete` | Yes | .
 
-## [clientv3util](https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util)
+## clientv3util
+https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `KeyExists` | Yes | No
 `KeyMissing` | Yes | No
 
-## [Concurrency](https://godoc.org/go.etcd.io/etcd/clientv3/concurrency)
+## Concurrency
+https://godoc.org/go.etcd.io/etcd/clientv3/concurrency
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -115,20 +123,23 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `STM Rev` | Yes | No
 `STM Del` | Yes | No
 
-## [Leasing](https://godoc.org/go.etcd.io/etcd/clientv3/leasing)
+## Leasing
+https://godoc.org/go.etcd.io/etcd/clientv3/leasing
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `NewKV(Client, prefix)` | Yes | No
 
-## [Mirror](https://godoc.org/go.etcd.io/etcd/clientv3/mirror)
+## Mirror
+https://godoc.org/go.etcd.io/etcd/clientv3/mirror
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `SyncBase` | Yes | No
 `SyncUpdates` | Yes | No
 
-## [Namespace](https://godoc.org/go.etcd.io/etcd/clientv3/namespace)
+## Namespace
+https://godoc.org/go.etcd.io/etcd/clientv3/namespace
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
@@ -136,19 +147,22 @@ Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 `Lease` | Yes | No
 `Watcher` | Yes | No
 
-## [Naming](https://godoc.org/go.etcd.io/etcd/clientv3/naming)
+## Naming
+https://godoc.org/go.etcd.io/etcd/clientv3/naming
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `GRPCResolver` | Yes | No
 
-## [Ordering](https://godoc.org/go.etcd.io/etcd/clientv3/ordering)
+## Ordering
+https://godoc.org/go.etcd.io/etcd/clientv3/ordering
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------
 `KV` | Yes | No
 
-## [Snapshot](https://godoc.org/go.etcd.io/etcd/clientv3/snapshot)
+## Snapshot
+https://godoc.org/go.etcd.io/etcd/clientv3/snapshot
 
 Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
 :-------|:--------------------|:--------------


### PR DESCRIPTION
This PR reformats the `learning/client-feature-matrix/` pages in v3.3.12 and v3.3.13 as per the conversation in issue https://github.com/etcd-io/website/issues/114.

I've done a quick search for "# [" anywhere else on the site, and think these are the only two instances of link-only section headings.

fixes: https://github.com/etcd-io/website/issues/114