### PR TITLE
Updating docs/learning/client feature matrices

### DIFF
--- a/content/docs/v3.3.12/learning/client-feature-matrix.md
+++ b/content/docs/v3.3.12/learning/client-feature-matrix.md
@@ -4,167 +4,182 @@ title: Client feature matrix
 
 ## Features
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-Automatic retry | Yes | .
-Retry backoff | Yes | .
-Automatic failover | Yes | .
-Load balancer |	Round-Robin | ·
-`WithRequireLeader(context.Context)` | Yes | .
-`TLS` | Yes | Yes
-`SetEndpoints` | Yes | .
-`Sync` endpoints | Yes | .
-`AutoSyncInterval` | Yes | .
-`KeepAlive` ping | Yes | .
-`MaxCallSendMsgSize` | Yes | .
-`MaxCallRecvMsgSize` | Yes | .
-`RejectOldCluster` | Yes | .
+| Feature                              | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                              | -------------------- | -------------- |
+| Automatic retry                      | Yes                  | .              |
+| Retry backoff                        | Yes                  | .              |
+| Automatic failover                   | Yes                  | .              |
+| Load balancer                        | Round-Robin          | .              |
+| `WithRequireLeader(context.Context)` | Yes                  | .              |
+| `TLS`                                | Yes                  | Yes            |
+| `SetEndpoints`                       | Yes                  | .              |
+| `Sync` endpoints                     | Yes                  | .              |
+| `AutoSyncInterval`                   | Yes                  | .              |
+| `KeepAlive` ping                     | Yes                  | .              |
+| `MaxCallSendMsgSize`                 | Yes                  | .              |
+| `MaxCallRecvMsgSize`                 | Yes                  | .              |
+| `RejectOldCluster`                   | Yes                  | .              |
 
 ## KV
-https://godoc.org/go.etcd.io/etcd/clientv3#KV
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Put` | Yes | .
-`Get` | Yes | .
-`Delete` | Yes | .
-`Compact` | Yes | .
-`Do(Op)` | Yes | .
-`Txn` | Yes | .
+| Feature   | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------   | -------------------- | -------------  |
+| `Put`     | Yes                  | .              |
+| `Get`     | Yes                  | .              |
+| `Delete`  | Yes                  | .              |
+| `Compact` | Yes                  | .              |
+| `Do(Op)`  | Yes                  | .              |
+| `Txn`     | Yes                  | .              |
+
+For details, see the [KV API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#KV).
 
 ## Lease
-https://godoc.org/go.etcd.io/etcd/clientv3#Lease
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Grant` | Yes | .
-`Revoke` | Yes | .
-`TimeToLive` | Yes | .
-`Leases` | Yes | .
-`KeepAlive` | Yes | .
-`KeepAliveOnce` | Yes | .
+| Feature         | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------         | -------------------- | -------------- |
+| `Grant`         | Yes                  | .              |
+| `Revoke`        | Yes                  | .              |
+| `TimeToLive`    | Yes                  | .              |
+| `Leases`        | Yes                  | .              |
+| `KeepAlive`     | Yes                  | .              |
+| `KeepAliveOnce` | Yes                  | .              |
+
+For details, see the [Lease API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Lease).
 
 ## Watcher
-https://godoc.org/go.etcd.io/etcd/clientv3#Watcher
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Watch` | Yes | Yes
-`RequestProgress` | Yes | .
+| Feature           | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------           | -------------------- | -------------- |
+| `Watch`           | Yes                  | Yes            |
+| `RequestProgress` | Yes                  | .              |
+
+For details, see the [Watcher API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Watcher).
 
 ## Cluster
-https://godoc.org/go.etcd.io/etcd/clientv3#Cluster
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`MemberList` | Yes | Yes
-`MemberAdd` | Yes | Yes
-`MemberRemove` | Yes | Yes
-`MemberUpdate` | Yes | Yes
+| Feature        | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------        | -------------------- | -------------- |
+| `MemberList`   | Yes                  | Yes            |
+| `MemberAdd`    | Yes                  | Yes            |
+| `MemberRemove` | Yes                  | Yes            |
+| `MemberUpdate` | Yes                  | Yes            |
+
+For details, see the [Cluster API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Cluster).
 
 ## Maintenance
-https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`AlarmList` | Yes | Yes
-`AlarmDisarm` | Yes | ·
-`Defragment` | Yes | ·
-`Status` | Yes | ·
-`HashKV` | Yes | ·
-`Snapshot` | Yes | ·
-`MoveLeader` | Yes | ·
+| Feature       | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------       | -------------------- | -------------- |
+| `AlarmList`   | Yes                  | Yes            |
+| `AlarmDisarm` | Yes                  | .              |
+| `Defragment`  | Yes                  | .              |
+| `Status`      | Yes                  | .              |
+| `HashKV`      | Yes                  | .              |
+| `Snapshot`    | Yes                  | .              |
+| `MoveLeader`  | Yes                  | .              |
+
+For details, see the [Maintenance API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Maintenance).
 
 ## Auth
-https://godoc.org/go.etcd.io/etcd/clientv3#Auth
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`AuthEnable` | Yes | .
-`AuthDisable` | Yes | .
-`UserAdd` | Yes | .
-`UserDelete` | Yes | .
-`UserChangePassword` | Yes | .
-`UserGrantRole` | Yes | .
-`UserGet` | Yes | .
-`UserList` | Yes | .
-`UserRevokeRole` | Yes | .
-`RoleAdd` | Yes | .
-`RoleGrantPermission` | Yes | .
-`RoleGet` | Yes | .
-`RoleList` | Yes | .
-`RoleRevokePermission` | Yes | .
-`RoleDelete` | Yes | .
+| Feature                | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                | -------------------- | -------------- |
+| `AuthEnable`           | Yes                  | .              |
+| `AuthDisable`          | Yes                  | .              |
+| `UserAdd`              | Yes                  | .              |
+| `UserDelete`           | Yes                  | .              |
+| `UserChangePassword`   | Yes                  | .              |
+| `UserGrantRole`        | Yes                  | .              |
+| `UserGet`              | Yes                  | .              |
+| `UserList`             | Yes                  | .              |
+| `UserRevokeRole`       | Yes                  | .              |
+| `RoleAdd`              | Yes                  | .              |
+| `RoleGrantPermission`  | Yes                  | .              |
+| `RoleGet`              | Yes                  | .              |
+| `RoleList`             | Yes                  | .              |
+| `RoleRevokePermission` | Yes                  | .              |
+| `RoleDelete`           | Yes                  | .              |
+
+For details, see the [Auth API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Auth).
 
 ## clientv3util
-https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KeyExists` | Yes | No
-`KeyMissing` | Yes | No
+| Feature      | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------      | -------------------- | -------------- |
+| `KeyExists`  | Yes                  | No             |
+| `KeyMissing` | Yes                  | No             |
+
+For details, see the [clientv3util API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/clientv3util).
 
 ## Concurrency
-https://godoc.org/go.etcd.io/etcd/clientv3/concurrency
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Session` | Yes | No
-`NewMutex(Session, prefix)` | Yes | No
-`NewElection(Session, prefix)` | Yes | No
-`NewLocker(Session, prefix)` | Yes | No
-`STM Isolation SerializableSnapshot` | Yes | No
-`STM Isolation Serializable` | Yes | No
-`STM Isolation RepeatableReads` | Yes | No
-`STM Isolation ReadCommitted` | Yes | No
-`STM Get` | Yes | No
-`STM Put` | Yes | No
-`STM Rev` | Yes | No
-`STM Del` | Yes | No
+| Feature                              | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                              | -------------------- | -------------- |
+| `Session`                            | Yes                  | No             |
+| `NewMutex(Session, prefix)`          | Yes                  | No             |
+| `NewElection(Session, prefix)`       | Yes                  | No             |
+| `NewLocker(Session, prefix)`         | Yes                  | No             |
+| `STM Isolation SerializableSnapshot` | Yes                  | No             |
+| `STM Isolation Serializable`         | Yes                  | No             |
+| `STM Isolation RepeatableReads`      | Yes                  | No             |
+| `STM Isolation ReadCommitted`        | Yes                  | No             |
+| `STM Get`                            | Yes                  | No             |
+| `STM Put`                            | Yes                  | No             |
+| `STM Rev`                            | Yes                  | No             |
+| `STM Del`                            | Yes                  | No             |
+
+For details, see the [Concurrency API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/concurrency).
 
 ## Leasing
-https://godoc.org/go.etcd.io/etcd/clientv3/leasing
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`NewKV(Client, prefix)` | Yes | No
+| Feature                 | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                 | -------------------- | -------------- |
+| `NewKV(Client, prefix)` | Yes                  | No             |
+
+For details, see the [Leasing API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/leasing).
 
 ## Mirror
-https://godoc.org/go.etcd.io/etcd/clientv3/mirror
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`SyncBase` | Yes | No
-`SyncUpdates` | Yes | No
+| Feature       | `clientv3-grpc1.14`   | `jetcd v0.0.2`  |
+| -------       | --------------------  | --------------  |
+| `SyncBase`    | Yes                   | No              |
+| `SyncUpdates` | Yes                   | No              |
+
+For details, see the [Mirror API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/mirror).
 
 ## Namespace
-https://godoc.org/go.etcd.io/etcd/clientv3/namespace
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KV` | Yes | No
-`Lease` | Yes | No
-`Watcher` | Yes | No
+| Feature   | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------   | -------------------- | -------------  |
+| `KV`      | Yes                  | No             |
+| `Lease`   | Yes                  | No             |
+| `Watcher` | Yes                  | No             |
+
+For details, see the [Namespace API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/namespace).
 
 ## Naming
-https://godoc.org/go.etcd.io/etcd/clientv3/naming
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`GRPCResolver` | Yes | No
+| Feature        | `clientv3-grpc1.14`   | `jetcd v0.0.2`  |
+| -------        | -------------------   | -------------   |
+| `GRPCResolver` | Yes                   | No              |
+
+For details, see the [Naming API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/naming).
 
 ## Ordering
-https://godoc.org/go.etcd.io/etcd/clientv3/ordering
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KV` | Yes | No
+| Feature        | `clientv3-grpc1.14`   | `jetcd v0.0.2`  |
+| -------        | -------------------   | -------------   |
+| `KV`           | Yes                   | No              |
+
+For details, see the [Ordering API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/ordering).
 
 ## Snapshot
-https://godoc.org/go.etcd.io/etcd/clientv3/snapshot
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Save` | Yes | No
-`Status` | Yes | No
-`Restore` | Yes | No
+| Feature   | `clientv3-grpc1.14`   | `jetcd v0.0.2`  |
+| -------   | --------------------  | --------------  |
+| `Save`    | Yes                   | No              |
+| `Status`  | Yes                   | No              |
+| `Restore` | Yes                   | No              |
+
+For details, see the [Snapshot API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/snapshot).
+

--- a/content/docs/v3.3.13/learning/client-feature-matrix.md
+++ b/content/docs/v3.3.13/learning/client-feature-matrix.md
@@ -4,168 +4,182 @@ title: Client feature matrix
 
 ## Features
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-Automatic retry | Yes | .
-Retry backoff | Yes | .
-Automatic failover | Yes | .
-Load balancer |	Round-Robin | ·
-`WithRequireLeader(context.Context)` | Yes | .
-`TLS` | Yes | Yes
-`SetEndpoints` | Yes | .
-`Sync` endpoints | Yes | .
-`AutoSyncInterval` | Yes | .
-`KeepAlive` ping | Yes | .
-`MaxCallSendMsgSize` | Yes | .
-`MaxCallRecvMsgSize` | Yes | .
-`RejectOldCluster` | Yes | .
+| Feature                              | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                              | -------------------- | -------------- |
+| Automatic retry                      | Yes                  | .              |
+| Retry backoff                        | Yes                  | .              |
+| Automatic failover                   | Yes                  | .              |
+| Load balancer                        | Round-Robin          | ·              |
+| `WithRequireLeader(context.Context)` | Yes                  | .              |
+| `TLS`                                | Yes                  | Yes            |
+| `SetEndpoints`                       | Yes                  | .              |
+| `Sync` endpoints                     | Yes                  | .              |
+| `AutoSyncInterval`                   | Yes                  | .              |
+| `KeepAlive` ping                     | Yes                  | .              |
+| `MaxCallSendMsgSize`                 | Yes                  | .              |
+| `MaxCallRecvMsgSize`                 | Yes                  | .              |
+| `RejectOldCluster`                   | Yes                  | .              |
 
 ## KV
-https://godoc.org/go.etcd.io/etcd/clientv3#KV
 
+| Feature   | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------   | -------------------- | -------------- |
+| `Put`     | Yes                  | .              |
+| `Get`     | Yes                  | .              |
+| `Delete`  | Yes                  | .              |
+| `Compact` | Yes                  | .              |
+| `Do(Op)`  | Yes                  | .              |
+| `Txn`     | Yes                  | .              |
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Put` | Yes | .
-`Get` | Yes | .
-`Delete` | Yes | .
-`Compact` | Yes | .
-`Do(Op)` | Yes | .
-`Txn` | Yes | .
+For details, see the [KV API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#KV).
 
 ## Lease
-https://godoc.org/go.etcd.io/etcd/clientv3#Lease
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Grant` | Yes | .
-`Revoke` | Yes | .
-`TimeToLive` | Yes | .
-`Leases` | Yes | .
-`KeepAlive` | Yes | .
-`KeepAliveOnce` | Yes | .
+| Feature         | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------         | -------------------- | -------------- |
+| `Grant`         | Yes                  | .              |
+| `Revoke`        | Yes                  | .              |
+| `TimeToLive`    | Yes                  | .              |
+| `Leases`        | Yes                  | .              |
+| `KeepAlive`     | Yes                  | .              |
+| `KeepAliveOnce` | Yes                  | .              |
+
+For details, see the [Lease API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Lease).
 
 ## Watcher
-https://godoc.org/go.etcd.io/etcd/clientv3#Watcher
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Watch` | Yes | Yes
-`RequestProgress` | Yes | .
+| Feature           | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------           | -------------------- | -------------- |
+| `Watch`           | Yes                  | Yes            |
+| `RequestProgress` | Yes                  | .              |
+
+For details, see the [Watcher API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Watcher).
 
 ## Cluster
-https://godoc.org/go.etcd.io/etcd/clientv3#Cluster
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`MemberList` | Yes | Yes
-`MemberAdd` | Yes | Yes
-`MemberRemove` | Yes | Yes
-`MemberUpdate` | Yes | Yes
+| Feature        | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------        | -------------------- | -------------- |
+| `MemberList`   | Yes                  | Yes            |
+| `MemberAdd`    | Yes                  | Yes            |
+| `MemberRemove` | Yes                  | Yes            |
+| `MemberUpdate` | Yes                  | Yes            |
+
+For details, see the [Cluster API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Cluster).
 
 ## Maintenance
-https://godoc.org/go.etcd.io/etcd/clientv3#Maintenance
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`AlarmList` | Yes | Yes
-`AlarmDisarm` | Yes | ·
-`Defragment` | Yes | ·
-`Status` | Yes | ·
-`HashKV` | Yes | ·
-`Snapshot` | Yes | ·
-`MoveLeader` | Yes | ·
+| Feature       | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------       | -------------------- | -------------- |
+| `AlarmList`   | Yes                  | Yes            |
+| `AlarmDisarm` | Yes                  | .              |
+| `Defragment`  | Yes                  | .              |
+| `Status`      | Yes                  | .              |
+| `HashKV`      | Yes                  | .              |
+| `Snapshot`    | Yes                  | .              |
+| `MoveLeader`  | Yes                  | .              |
+
+For details, see the [Maintenance API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Maintenance).
 
 ## Auth
-https://godoc.org/go.etcd.io/etcd/clientv3#Auth
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`AuthEnable` | Yes | .
-`AuthDisable` | Yes | .
-`UserAdd` | Yes | .
-`UserDelete` | Yes | .
-`UserChangePassword` | Yes | .
-`UserGrantRole` | Yes | .
-`UserGet` | Yes | .
-`UserList` | Yes | .
-`UserRevokeRole` | Yes | .
-`RoleAdd` | Yes | .
-`RoleGrantPermission` | Yes | .
-`RoleGet` | Yes | .
-`RoleList` | Yes | .
-`RoleRevokePermission` | Yes | .
-`RoleDelete` | Yes | .
+| Feature                | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                | -------------------- | -------------- |
+| `AuthEnable`           | Yes                  | .              |
+| `AuthDisable`          | Yes                  | .              |
+| `UserAdd`              | Yes                  | .              |
+| `UserDelete`           | Yes                  | .              |
+| `UserChangePassword`   | Yes                  | .              |
+| `UserGrantRole`        | Yes                  | .              |
+| `UserGet`              | Yes                  | .              |
+| `UserList`             | Yes                  | .              |
+| `UserRevokeRole`       | Yes                  | .              |
+| `RoleAdd`              | Yes                  | .              |
+| `RoleGrantPermission`  | Yes                  | .              |
+| `RoleGet`              | Yes                  | .              |
+| `RoleList`             | Yes                  | .              |
+| `RoleRevokePermission` | Yes                  | .              |
+| `RoleDelete`           | Yes                  | .              |
+
+For details, see the [Auth API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3#Auth).
 
 ## clientv3util
-https://godoc.org/go.etcd.io/etcd/clientv3/clientv3util
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KeyExists` | Yes | No
-`KeyMissing` | Yes | No
+| Feature      | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------      | -------------------- | -------------- |
+| `KeyExists`  | Yes                  | No             |
+| `KeyMissing` | Yes                  | No             |
+
+For details, see the [clientv3util API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/clientv3util).
 
 ## Concurrency
-https://godoc.org/go.etcd.io/etcd/clientv3/concurrency
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Session` | Yes | No
-`NewMutex(Session, prefix)` | Yes | No
-`NewElection(Session, prefix)` | Yes | No
-`NewLocker(Session, prefix)` | Yes | No
-`STM Isolation SerializableSnapshot` | Yes | No
-`STM Isolation Serializable` | Yes | No
-`STM Isolation RepeatableReads` | Yes | No
-`STM Isolation ReadCommitted` | Yes | No
-`STM Get` | Yes | No
-`STM Put` | Yes | No
-`STM Rev` | Yes | No
-`STM Del` | Yes | No
+| Feature                              | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                              | -------------------- | -------------- |
+| `Session`                            | Yes                  | No             |
+| `NewMutex(Session, prefix)`          | Yes                  | No             |
+| `NewElection(Session, prefix)`       | Yes                  | No             |
+| `NewLocker(Session, prefix)`         | Yes                  | No             |
+| `STM Isolation SerializableSnapshot` | Yes                  | No             |
+| `STM Isolation Serializable`         | Yes                  | No             |
+| `STM Isolation RepeatableReads`      | Yes                  | No             |
+| `STM Isolation ReadCommitted`        | Yes                  | No             |
+| `STM Get`                            | Yes                  | No             |
+| `STM Put`                            | Yes                  | No             |
+| `STM Rev`                            | Yes                  | No             |
+| `STM Del`                            | Yes                  | No             |
+
+For details, see the [Concurrency API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/concurrency).
 
 ## Leasing
-https://godoc.org/go.etcd.io/etcd/clientv3/leasing
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`NewKV(Client, prefix)` | Yes | No
+| Feature                 | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------                 | -------------------- | -------------- |
+| `NewKV(Client, prefix)` | Yes                  | No             |
+
+For details, see the [Leasing API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/leasing).
 
 ## Mirror
-https://godoc.org/go.etcd.io/etcd/clientv3/mirror
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`SyncBase` | Yes | No
-`SyncUpdates` | Yes | No
+| Feature       | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------       | -------------------- | -------------- |
+| `SyncBase`    | Yes                  | No             |
+| `SyncUpdates` | Yes                  | No             |
+
+For details, see the [Mirror API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/mirror).
 
 ## Namespace
-https://godoc.org/go.etcd.io/etcd/clientv3/namespace
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KV` | Yes | No
-`Lease` | Yes | No
-`Watcher` | Yes | No
+| Feature   | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------   | -------------------- | -------------- |
+| `KV`      | Yes                  | No             |
+| `Lease`   | Yes                  | No             |
+| `Watcher` | Yes                  | No             |
+
+For details, see the [Namespace API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/namespace).
 
 ## Naming
-https://godoc.org/go.etcd.io/etcd/clientv3/naming
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`GRPCResolver` | Yes | No
+| Feature        | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------        | -------------------- | -------------- |
+| `GRPCResolver` | Yes                  | No             |
+
+For details, see the [Naming API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/naming).
 
 ## Ordering
-https://godoc.org/go.etcd.io/etcd/clientv3/ordering
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`KV` | Yes | No
+| Feature | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| ------- | -------------------- | -------------- |
+| `KV`    | Yes                  | No             |
+
+For details, see the [Ordering API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/ordering).
 
 ## Snapshot
-https://godoc.org/go.etcd.io/etcd/clientv3/snapshot
 
-Feature | `clientv3-grpc1.14` | `jetcd v0.0.2`
-:-------|:--------------------|:--------------
-`Save` | Yes | No
-`Status` | Yes | No
-`Restore` | Yes | No
+| Feature   | `clientv3-grpc1.14`  | `jetcd v0.0.2` |
+| -------   | -------------------- | -------------- |
+| `Save`    | Yes                  | No             |
+| `Status`  | Yes                  | No             |
+| `Restore` | Yes                  | No             |
+
+For details, see the [Snapshot API reference](https://pkg.go.dev/go.etcd.io/etcd/clientv3/snapshot).
+


### PR DESCRIPTION
Updating docs/learning/client feature matrices:
* Removing raw URLs, adding "for details..." text
* Updating links from godoc.org to pkg.go.dev
* Cleaning up tables

fixes: https://github.com/etcd-io/website/issues/119

/cc @chalin @spzala 