### PR TITLE
Upgrading to Hugo 0.81.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ resources/
 # Link checker artifacts
 bin/
 tmp/
+
+# Local Netlify folder
+.netlify
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMG = klakegg/hugo:0.80.0-ext
+DOCKER_IMG = klakegg/hugo:0.81.0-ext-asciidoctor
 SERVER     = server --buildDrafts --buildFuture --disableFastRender --ignoreCache
 
 setup:

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.65.0"
+HUGO_VERSION = "0.81.0"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
Updating netlify.toml, Makefile, and .gitignore.
* netlify.toml updated to use latest Hugo version
* Makefile updated to use latest extended version of Hugo, matching the docsy-example site (using -asciidoctor)
* .gitignore to ignore .netlify folder -- created when testing netlify locally.

Fixes: https://github.com/etcd-io/website/issues/113

/cc @chalin @spzala 