### PR TITLE
Generate production-mode CSS in production mode only

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,12 +1,12 @@
-{{- $inServerMode := .Site.IsServer }}
+{{- $inDevMode := ne hugo.IsProduction }}
 {{- $includePaths := (slice "node_modules") }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}
 {{- $devOpts      := (dict "targetPath" $cssOutput "includePaths" $includePaths "enableSourceMap" true) }}
 {{- $prodOpts     := (dict "targetPath" $cssOutput "includePaths" $includePaths "outputStyle" "compressed") }}
-{{- $cssOpts      := cond $inServerMode $devOpts $prodOpts }}
+{{- $cssOpts      := cond $inDevMode $devOpts $prodOpts }}
 {{- $css          := resources.Get $sass | resources.ExecuteAsTemplate $sass . | toCSS $cssOpts }}
-{{- if $inServerMode }}
+{{- if $inDevMode }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 {{- else }}
 {{- $prodCss      := $css | fingerprint }}


### PR DESCRIPTION
Hugo docs don't use the term "mode", they instead use "environment", but that just makes things confusing. For details concerning the development vs. production "mode" (i.e., "environment"), see [Hugo > Functions > hugo](https://gohugo.io/functions/hugo/).

(This file needs some more cleanup, but I wanted to keep diffs to a minimum for now.)