### PR TITLE
Add docsy submodule without using it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "themes/docsy"]
+  path = themes/docsy
+  url = https://github.com/cncf/docsy.git
+  branch = etcd.io

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,12 +1,12 @@
-{{- $inServerMode := .Site.IsServer }}
+{{- $inDevMode := ne hugo.IsProduction }}
 {{- $includePaths := (slice "node_modules") }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}
 {{- $devOpts      := (dict "targetPath" $cssOutput "includePaths" $includePaths "enableSourceMap" true) }}
 {{- $prodOpts     := (dict "targetPath" $cssOutput "includePaths" $includePaths "outputStyle" "compressed") }}
-{{- $cssOpts      := cond $inServerMode $devOpts $prodOpts }}
+{{- $cssOpts      := cond $inDevMode $devOpts $prodOpts }}
 {{- $css          := resources.Get $sass | resources.ExecuteAsTemplate $sass . | toCSS $cssOpts }}
-{{- if $inServerMode }}
+{{- if $inDevMode }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 {{- else }}
 {{- $prodCss      := $css | fingerprint }}


### PR DESCRIPTION
**IMPORTANT**: #124 needs to be merged first.

This PR has no impact on the site generation, but it will ease development during the conversion to docsy (#94) by allowing us to switch between `master` and `docsy` branches without having to deal with an uncommitted submodule.