### PR TITLE
testing netlify.toml and Netlify deploy preview for docsy PRs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,8 @@ command = "make preview-build"
   [context.banch-deploy.headers.values]
     X-Robots-Tag = "noindex"
 
+# An edit to test the context above.
+
 [[redirects]]
 from = "/docs/v3.4.0/branch-management"
 to = "/docs/v3.4.0/branch_management"


### PR DESCRIPTION
This PR should trigger a deploy preview with `X-Robots-Tag` header set to `noindex`

verifies https://github.com/etcd-io/website/issues/127 & https://github.com/etcd-io/website/issues/128