### PR TITLE
Updating links in current folder based on PRs for older versions

### DIFF
--- a/content/docs/current/integrations.md
+++ b/content/docs/current/integrations.md
@@ -17,7 +17,6 @@ description: A listing of etcd tools and client libraries
 - [etcd-viewer](https://github.com/nikfoundas/etcd-viewer) - An etcd key-value store editor/viewer written in Java
 - [etcdtool](https://github.com/mickep76/etcdtool) - Export/Import/Edit etcd directory as JSON/YAML/TOML and Validate directory using JSON schema
 - [etcd-rest](https://github.com/mickep76/etcd-rest) - Create generic REST API in Go using etcd as a backend with validation using JSON schema
-- [etcdsh](https://github.com/kamilhark/etcdsh) - A command line client with support of command history and tab completion. Supports v2
 - [etcdloadtest](https://github.com/sinsharat/etcdloadtest) - A command line load test client for etcd version 3.0 and above.
 - [lucas](https://github.com/ringtail/lucas) - A web-based key-value viewer for kubernetes etcd3.0+ cluster.
 - [etcd-manager](https://etcdmanager.io) - A modern, efficient, multi-platform and free ETCD 3.x GUI & client tool. Available for Windows, Linux and Mac.


### PR DESCRIPTION
* updating current/integration.md
  removing etcdsh as the repo has been removed.
  as per https://github.com/etcd-io/website/pull/92

Contributes to #87 