### PR TITLE
Updating Makefile, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ tmp/
 
 # Local Netlify folder
 .netlify
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # npm assets
 node_modules/
+package-lock.json
 
 # Hugo-generated assets
 /public

--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -1,0 +1,3 @@
+DirectoryPath: public
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreAltMissing: true

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,44 @@
+# Args based on grcp/grpc.io's Makefile
+# https://github.com/grpc/grpc.io/blob/main/Makefile
+
+DRAFT_ARGS = --buildDrafts --buildFuture --disableFastRender --ignoreCache
+BUILD_ARGS = --minify
 DOCKER_IMG = klakegg/hugo:0.81.0-ext-asciidoctor
-SERVER     = server --buildDrafts --buildFuture --disableFastRender --ignoreCache
+ifeq (draft, $(or $(findstring draft,$(HEAD)),$(findstring draft,$(BRANCH))))
+BUILD_ARGS += $(DRAFT_ARGS)
+endif
+
+clean:
+	rm -rf public/* resources
 
 setup:
 	npm install
 
 serve:
-	hugo $(SERVER)
+	@./check_hugo.sh
+	hugo serve
 
-docker-serve:
-	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) $(SERVER)
+serve-drafts:
+	@./check_hugo.sh
+	hugo serve $(DRAFT_ARGS)
 
-production-build:
+serve-production: clean
+	@./check_hugo.sh
+	hugo serve -e production --minify
+
+production-build: clean
+	@./check_hugo.sh
 	hugo --minify
 
-preview-build:
+preview-build: clean
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \
 		--buildFuture \
 		--minify
 
-clean:
-	rm -rf public
+docker-serve:
+	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) server $(DRAFT_ARGS)
 
 link-checker-setup:
 	# https://wjdp.uk/work/htmltest/
@@ -31,4 +48,10 @@ run-link-checker:
 	bin/htmltest
 
 check-links: clean production-build link-checker-setup run-link-checker
+
+# Adding additional link checks based on https://github.com/grpc/grpc.io/blob/main/Makefile
+check-internal-links: production-build link-checker-setup run-link-checker
+
+check-all-links: production-build link-checker-setup
+	bin/htmltest --conf .htmltest.external.yml
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Args based on grcp/grpc.io's Makefile
 # https://github.com/grpc/grpc.io/blob/main/Makefile
 
-DRAFT_ARGS = --buildDrafts --buildFuture --disableFastRender --ignoreCache
+DRAFT_ARGS = --buildDrafts --buildFuture
 BUILD_ARGS = --minify
 DOCKER_IMG = klakegg/hugo:0.81.0-ext-asciidoctor
 ifeq (draft, $(or $(findstring draft,$(HEAD)),$(findstring draft,$(BRANCH))))
@@ -31,11 +31,9 @@ production-build: clean
 	hugo --minify
 
 preview-build: clean
-	hugo \
-		--baseURL $(DEPLOY_PRIME_URL) \
-		--buildDrafts \
-		--buildFuture \
-		--minify
+	@./check_hugo.sh
+	hugo --baseURL $(DEPLOY_PRIME_URL) \
+		-e development $(BUILD_ARGS)
 
 docker-serve:
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) server $(DRAFT_ARGS)

--- a/check_hugo.sh
+++ b/check_hugo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# based on gnossen's check_hugo.sh file:
+# https://github.com/grpc/grpc.io/blob/main/check_hugo.sh
+
+set -e
+
+command -v hugo >/dev/null || (echo "Hugo extended must be installed on your system." >/dev/stderr; exit 1)
+hugo version | grep -i extended >/dev/null || (echo "Your Hugo installation does not appear to be extended." >/dev/stderr; exit 1)
+


### PR DESCRIPTION
Updating Makefile to check hugo version is extended, adding link cheking options, adding DRAFT_ARGS
updating .gitignore to include .lock file to continue the work of issue https://github.com/etcd-io/website/issues/141

/cc @chalin 