### PR TITLE
updating references to client v2 to link to v2

### DIFF
--- a/content/docs/next/integrations.md
+++ b/content/docs/next/integrations.md
@@ -28,8 +28,8 @@ The sections below list etcd client libraries by language.
 
 ### Go
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/next/integrations.md
+++ b/content/docs/next/integrations.md
@@ -28,8 +28,8 @@ The sections below list etcd client libraries by language.
 
 ### Go
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client](https://github.com/etcd-io/etcd/blob/master/client) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/v2.3/clustering.md
+++ b/content/docs/v2.3/clustering.md
@@ -432,7 +432,7 @@ To make understanding this feature easier, we changed the naming of some flags, 
 |-peers      |none      |Deprecated. The --initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|
 |-peers-file    |none      |Deprecated. The --initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|
 
-[client]: ../../client
+[client]: https://github.com/etcd-io/etcd/tree/master/client/v2
 [client-discoverer]: https://godoc.org/github.com/coreos/etcd/client#Discoverer
 [conf-adv-client]: configuration.md#-advertise-client-urls
 [conf-listen-client]: configuration.md#-listen-client-urls

--- a/content/docs/v2.3/libraries-and-tools.md
+++ b/content/docs/v2.3/libraries-and-tools.md
@@ -19,7 +19,8 @@ title: Libraries and Tools
 
 **Go libraries**
 
-- [etcd/client](https://github.com/etcd-io/etcd/blob/master/client) - the officially maintained Go client
+- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 
 **Java libraries**

--- a/content/docs/v2.3/libraries-and-tools.md
+++ b/content/docs/v2.3/libraries-and-tools.md
@@ -19,8 +19,8 @@ title: Libraries and Tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 
 **Java libraries**

--- a/content/docs/v2.3/libraries-and-tools.md
+++ b/content/docs/v2.3/libraries-and-tools.md
@@ -19,7 +19,6 @@ title: Libraries and Tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
 - [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 

--- a/content/docs/v3.1/libraries-and-tools.md
+++ b/content/docs/v3.1/libraries-and-tools.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 
 **Java libraries**

--- a/content/docs/v3.1/libraries-and-tools.md
+++ b/content/docs/v3.1/libraries-and-tools.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client](https://github.com/coreos/etcd/blob/master/client) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 
 **Java libraries**

--- a/content/docs/v3.2/integrations.md
+++ b/content/docs/v3.2/integrations.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/v3.2/integrations.md
+++ b/content/docs/v3.2/integrations.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client](https://github.com/coreos/etcd/blob/master/client) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/v3.3/integrations.md
+++ b/content/docs/v3.3/integrations.md
@@ -22,8 +22,8 @@ weight: 2
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/v3.3/integrations.md
+++ b/content/docs/v3.3/integrations.md
@@ -22,8 +22,8 @@ weight: 2
 
 **Go libraries**
 
-- [etcd/clientv3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client](https://github.com/etcd-io/etcd/blob/master/client) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/docs/v3.4/integrations.md
+++ b/content/docs/v3.4/integrations.md
@@ -22,8 +22,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/blob/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/blob/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 


### PR DESCRIPTION
updating references to client v2 to link to v2

fixes: https://github.com/etcd-io/website/issues/148
contributes to: https://github.com/etcd-io/website/issues/87
/cc @chalin
