### PR TITLE
Moving redirects: `netlify.toml` → `layouts/index.redirects`

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,6 +1,8 @@
 {{ $latest := site.Params.versions.latest }}
 /docs/latest     /docs/{{ $latest }}/
 /docs/latest/*     /docs/{{ $latest }}/:splat
+/docs/v3.4.0/branch-management    /docs/v3.4.0/branch_management/
+docs/v3.4.0/reporting-bugs    /docs/v3.4.0/reporting_bugs/
 /docs/current     /docs/next/
 /docs/current/*     /docs/next/:splat
 /docs/v2    /docs/v2.3/

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,15 +21,3 @@ command = "npm run preview-build"
   [context.banch-deploy.headers.values]
     X-Robots-Tag = "noindex"
 
-[[redirects]]
-from = "/docs/v3.4.0/branch-management"
-to = "/docs/v3.4.0/branch_management"
-status = 301
-force = false
-
-[[redirects]]
-from = "/docs/v3.4.0/reporting-bugs"
-to = "/docs/v3.4.0/reporting_bugs"
-status = 301
-force = false
-


### PR DESCRIPTION
Moving redirects from `netlify.toml` file to `layouts/index.redirects` file

Fixes: https://github.com/etcd-io/website/issues/138
/cc @chalin 