### PR TITLE
Docs landing page fixes

### DIFF
--- a/layouts/docs/section.en.html
+++ b/layouts/docs/section.en.html
@@ -4,15 +4,17 @@ etcd | {{ .Title }}
 
 {{ define "main" }}
 {{ partial "docs/navbar.html" . }}
-{{ $version := index (split .Path "/") 1 }}
+{{ $version := index (split .RelPermalink "/") 2 }}
 {{ $isVersionMainPage := eq .RelPermalink (printf "/docs/%s/" $version) }}
 <div class="dashboard">
   {{ partial "docs/nav-panel.html" . }}
 
   <div class="dashboard-main is-scrollable">
-    {{ partial "docs/hero.html" . }}
+    {{ partial "docs/hero.html" . -}}
 
+    {{ if $version -}}
     {{ partial "deprecation-warning.html" . }}
+    {{ end -}}
 
     <section class="section">
       <div class="content docs-content">
@@ -38,7 +40,7 @@ etcd | {{ .Title }}
           </li>
           {{ end }}
         </ul>
-        {{ else }}
+        {{ else if $version }}
         <h4>
           Docs in this section
         </h4>
@@ -58,7 +60,7 @@ etcd | {{ .Title }}
         {{ end }}
       </div>
     </section>
-      
+
 
     {{ partial "footer.html" . }}
   </div>

--- a/layouts/partials/docs/nav-panel.html
+++ b/layouts/partials/docs/nav-panel.html
@@ -3,7 +3,7 @@
 {{ $editUrl    := printf "https://github.com/etcd-io/website/edit/master/content/%s" .File.Path }}
 {{ $latest     := site.Params.versions.latest }}
 {{ $ghUrl      := printf "https://github.com/etcd-io/etcd/releases/tag/v%s" $latest }}
-{{ $version    := index (split .Path "/") 1 }}
+{{ $version    := index (split .RelPermalink "/") 2 }}
 {{ $allDocs    := where site.Sections "Section" "docs" }}
 
 <div class="dashboard-panel is-medium has-background-white-bis is-hidden-mobile">
@@ -19,7 +19,7 @@
         <button class="button is-danger is-radiusless">
           <span>
             <strong>
-              {{ $version }}
+              {{ $version | default "Version" }}
             </strong>
           </span>
           <span class="icon is-small">
@@ -42,15 +42,15 @@
 
           {{/* check if the file we are linking to in the other version exists */}}
           {{ if (fileExists $target_file) -}}
-          <a class="dropdown-item" 
+          <a class="dropdown-item"
              href="{{ replace $currentUrl $original_version $new_version | relURL }}">{{ . }}</a>
           {{ else }}
           {{/* if not, then link to the top level of that version instead */}}
           {{ if eq "/next/" $new_version }}
-          <a class="navbar-item" 
+          <a class="navbar-item"
              href="{{ index (findRE `^(.*?)\/next\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
           {{ else }}
-          <a class="navbar-item" 
+          <a class="navbar-item"
              href="{{ index (findRE `^(.*?)\/v\d+.\d+\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
           {{ end }}
           {{- end }}
@@ -64,9 +64,11 @@
 
   <div class="dashboard-panel-main is-scrollable">
     <div class="docs-panel">
+      {{ with $version -}}
       <a class="docs-panel-section" href="/docs/{{ $version }}">
-        Version {{ $version | replaceRE "v" "" }} home
+        Version {{ replace . "v" "" }} home
       </a>
+      {{ end -}}
 
       {{ range $allDocs }}
       {{ range .Sections }}


### PR DESCRIPTION
- Closes #177
- There are no changes to the generated site (modulo insignificant whitespace), other than the fixes to the doc landing page.

/reviewer @nate-double-u 

### Before

> ![image](https://user-images.githubusercontent.com/4140793/113299784-3b8c5100-92cb-11eb-81d4-0db8622b3a98.png)

### After

> 
![image](https://user-images.githubusercontent.com/4140793/113321098-40f49600-92e1-11eb-8313-7eb515fb053c.png)


### Diff

```console
$ git diff -b -w --ignore-blank-lines -I "_index.md|Version"
diff --git a/docs/index.html b/docs/index.html
index 5f24491..12653f0 100644
--- a/docs/index.html
+++ b/docs/index.html
@@ -352,10 +352,6 @@ etcd | The etcd documentation
 
   <div class="dashboard-panel-main is-scrollable">
     <div class="docs-panel">
-      <a class="docs-panel-section" href="/docs/_index.md">
-        Version _index.md home
-      </a>
-
       
       
       
@@ -1170,38 +1166,6 @@ etcd | The etcd documentation
     </nav>
   </div>
 </section>
-
-
-    
-
-
-
-
-
-
-
-
-
-
-
-<section class="section" id="deprecation-warning">
-  <div class="content deprecation-warning">
-    <h3>
-      You are viewing documentation for etcd version: 
-    </h3>
-    <p> etcd  documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see the latest release,
-    
-    <a href="/docs/">v3.4</a>, or the
-    <a href="/docs/">current documentation</a>.
-    
-    </p>
-  </div>
-</section>
-
-
-
-
-
 <section class="section">
       <div class="content docs-content">
         
@@ -1254,68 +1218,6 @@ etcd | The etcd documentation
 
 
         
-        <h4>
-          Docs in this section
-        </h4>
-
-        <ul>
-          
-          
-          <li>
-            <a href="/docs/next/">
-              etcd next version
-            </a><br />
-            
-          </li>
-          
-          
-          
-          <li>
-            <a href="/docs/v2.3/">
-              etcd version 2.3
-            </a><br />
-            
-          </li>
-          
-          
-          
-          <li>
-            <a href="/docs/v3.1/">
-              etcd version 3.1
-            </a><br />
-            
-          </li>
-          
-          
-          
-          <li>
-            <a href="/docs/v3.2/">
-              etcd version 3.2
-            </a><br />
-            
-          </li>
-          
-          
-          
-          <li>
-            <a href="/docs/v3.3/">
-              etcd version 3.3
-            </a><br />
-            
-          </li>
-          
-          
-          
-          <li>
-            <a href="/docs/v3.4/">
-              etcd version 3.4
-            </a><br />
-            
-          </li>
-          
-          
-        </ul>
-        
       </div>
     </section>
```
