### PR TITLE
Template cleanup: avoid generating excessive whitespace

### DIFF
--- a/layouts/_default/baseof.en.html
+++ b/layouts/_default/baseof.en.html
@@ -1,20 +1,20 @@
-{{ $langCode := .Site.LanguageCode }}
-{{ $isBlog   := eq .Section "blog" }}
+{{ $langCode := .Site.LanguageCode -}}
+{{ $isBlog   := eq .Section "blog" -}}
 <!DOCTYPE html>
 <html lang="{{ $langCode }}">
   <head>
-    {{ partial "google-analytics.html" . }}
-    {{ partial "meta.html" . }}
+    {{ partial "google-analytics.html" . -}}
+    {{ partial "meta.html" . -}}
     <title>
-      {{ block "title" . }}{{ .Site.Title }}{{ end }}
+      {{- block "title" . }}{{ .Site.Title }}{{ end -}}
     </title>
-    {{ partial "favicon.html" . }}
-    {{ partial "css.html" . }}
+    {{ partial "favicon.html" . -}}
+    {{ partial "css.html" . -}}
   </head>
   <body class="page{{ if $isBlog }} has-navbar-fixed-top{{ end }}">
-    {{ block "main" . }}
-    {{ end }}
+    {{ block "main" . -}}
+    {{ end -}}
 
-    {{ partial "javascript.html" . }}
+    {{ partial "javascript.html" . -}}
   </body>
 </html>

--- a/layouts/docs/section.en.html
+++ b/layouts/docs/section.en.html
@@ -1,11 +1,11 @@
-{{ define "title" }}
-etcd | {{ .Title }}
+{{ define "title" -}}
+etcd | {{ .Title -}}
 {{ end }}
 
-{{ define "main" }}
-{{ partial "docs/navbar.html" . }}
-{{ $version := index (split .RelPermalink "/") 2 }}
-{{ $isVersionMainPage := eq .RelPermalink (printf "/docs/%s/" $version) }}
+{{ define "main" -}}
+{{ partial "docs/navbar.html" . -}}
+{{ $version := index (split .RelPermalink "/") 2 -}}
+{{ $isVersionMainPage := eq .RelPermalink (printf "/docs/%s/" $version) -}}
 <div class="dashboard">
   {{ partial "docs/nav-panel.html" . }}
 
@@ -18,51 +18,43 @@ etcd | {{ .Title }}
 
     <section class="section">
       <div class="content docs-content">
-        {{ with .Content }}
-        {{ . }}
-
-        <hr />
-        {{ end }}
+        {{ with .Content -}}
+          {{ . -}}
+          <hr />
+        {{ end -}}
 
 
         {{ if and $isVersionMainPage .Sections }}
-        <h4>
-          Documentation sections
-        </h4>
+          <h4>Documentation sections</h4>
 
-        <ul>
-          {{ range .Sections }}
-          <li>
-            <a href="{{ .RelPermalink }}">
-              {{ .Title }}
-            </a><br />
-            {{ .Description }}
-          </li>
-          {{ end }}
-        </ul>
-        {{ else if $version }}
-        <h4>
-          Docs in this section
-        </h4>
-
-        <ul>
-          {{ range .Pages }}
-          {{ if .Title }}
-          <li>
-            <a href="{{ .RelPermalink }}">
-              {{ .Title }}
-            </a><br />
-            {{ .Description }}
-          </li>
-          {{ end }}
-          {{ end }}
-        </ul>
-        {{ end }}
+          <ul>
+            {{ range .Sections }}
+              <li>
+                <a href="{{ .RelPermalink }}">
+                  {{- .Title -}}
+                </a><br />
+                {{- .Description -}}
+              </li>
+            {{ end -}}
+          </ul>
+        {{ else if $version -}}
+          <h4>Docs in this section</h4>
+          <ul>
+            {{ range .Pages }}
+              {{ if .Title -}}
+              <li>
+                <a href="{{ .RelPermalink }}">
+                  {{- .Title -}}
+                </a><br />
+                {{- .Description -}}
+              </li>
+              {{ end -}}
+            {{ end -}}
+          </ul>
+        {{ end -}}
       </div>
     </section>
-
-
-    {{ partial "footer.html" . }}
+    {{ partial "footer.html" . -}}
   </div>
 </div>
-{{ end }}
+{{ end -}}

--- a/layouts/docs/single.en.html
+++ b/layouts/docs/single.en.html
@@ -1,22 +1,17 @@
-{{ define "title" }}
-etcd docs | {{ .Title }}
+{{ define "title" -}}
+etcd docs | {{ .Title -}}
 {{ end }}
 
-{{ define "main" }}
+{{ define "main" -}}
 {{ partial "docs/navbar.html" . }}
 <div class="dashboard">
   {{ partial "docs/nav-panel.html" . }}
-
   <div class="dashboard-main is-scrollable">
-    {{ partial "docs/hero.html" . }}
-
-    {{ partial "deprecation-warning.html" . }}
-
-    {{ partial "docs/article.html" . }}
-
-    {{ partial "footer.html" . }}
+    {{ partial "docs/hero.html" . -}}
+    {{ partial "deprecation-warning.html" . -}}
+    {{ partial "docs/article.html" . -}}
+    {{ partial "footer.html" . -}}
   </div>
-
-  {{ partial "docs/toc.html" . }}
+  {{ partial "docs/toc.html" . -}}
 </div>
-{{ end }}
+{{ end -}}

--- a/layouts/partials/docs/dashboard.html
+++ b/layouts/partials/docs/dashboard.html
@@ -1,11 +1,11 @@
 
 <div class="dashboard">
-  {{ partial "docs/nav-panel.html" . }}
+  {{ partial "docs/nav-panel.html" . -}}
 
   <div class="dashboard-main">
-    {{ partial "docs/hero.html" . }}
-    {{ partial "docs/article.html" . }}
+    {{ partial "docs/hero.html" . -}}
+    {{ partial "docs/article.html" . -}}
   </div>
 
-  {{ partial "docs/toc.html" . }}
+  {{ partial "docs/toc.html" . -}}
 </div>

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -1,95 +1,86 @@
-{{ $version      := index (split .File.Path "/") 1 }}
-{{ $latest       := printf "%s" site.Params.versions.latest }}
-{{ $allVersions  := site.Params.versions.all }}
-{{ $versions     := (slice) }}
-{{ $here         := .RelPermalink }}
-{{ $path         := .File.Path }}
-{{ range $allVersions }}
-{{ $v := printf "v%s" . }}
-{{ $fileToCheck := replace $path $version $v }}
-{{ if fileExists $fileToCheck }}
-{{ $versions = $versions | append . }}
-{{ end }}
-{{ end }}
+{{ $version      := index (split .File.Path "/") 1 -}}
+{{ $latest       := printf "%s" site.Params.versions.latest -}}
+{{ $allVersions  := site.Params.versions.all -}}
+{{ $versions     := (slice) -}}
+{{ $here         := .RelPermalink -}}
+{{ $path         := .File.Path -}}
+
+{{ range $allVersions -}}
+  {{ $v := printf "v%s" . -}}
+  {{ $fileToCheck := replace $path $version $v -}}
+  {{ if fileExists $fileToCheck -}}
+    {{ $versions = $versions | append . -}}
+  {{ end -}}
+{{ end -}}
 
 <section class="hero">
   <div class="hero-body">
     <p class="title is-size-1 is-size-2-mobile has-text-weight-light{{ if .Params.description }} is-spaced{{ end }}">
-    {{ .Title }}
+    {{- .Title -}}
     </p>
-    {{ with .Params.description }}
-    <p class="subtitle is-size-4 is-size-5-mobile">
-    {{ . | markdownify }}
-    </p>
+    {{ with .Params.description -}}
+      <p class="subtitle is-size-4 is-size-5-mobile">
+      {{- . | markdownify -}}
+      </p>
     {{ end }}
 
     <nav class="level">
       <div class="level-left">
         <div class="level-item">
-          <p class="is-size-4 is-size-5-mobile">
-          Versions of this doc:
-          </p>
+          <p class="is-size-4 is-size-5-mobile">Versions of this doc:</p>
         </div>
 
-        {{ $current_file := .File }}
+        {{ $current_file := .File -}}
 
-        {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
-        {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest | relURL }}
+        {{ $original_version := printf "/%s/" .CurrentSection.Params.version -}}
+        {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest | relURL -}}
 
         <div class="level-item">
           <div class="buttons">
             {{ range .Site.Params.versions.all }}
 
-            {{ $new_version := printf "/%s/" . }}
-            {{ $target_file := replace $current_file $original_version $new_version }}
-            {{ $isLatest := eq $latest . }}
+              {{ $new_version := printf "/%s/" . -}}
+              {{ $target_file := replace $current_file $original_version $new_version -}}
+              {{ $isLatest := eq $latest . -}}
 
-            {{/* check if the file we are linking to in the other version exists */}}
-            {{ if (fileExists $target_file) -}}
-            <a class="button is-primary is-outlined has-text-weight-bold"
-               href="{{ replace $here $original_version $new_version | relURL }}">
-              <span>
-                {{ . }}
-              </span>
-              {{ if $isLatest }}
-              &nbsp;&nbsp;
-              <span class="tag is-small is-success">
-                latest
-              </span>
-              {{ end }}
-            </a>
-            {{ else }}
-            {{/* if not, then link to the top level of that version instead */}}
-            {{ if eq "/next/" $new_version }}
-            <a class="button is-primary is-outlined has-text-weight-bold"
-               href="{{ index (findRE `^(.*?)\/next\/` (replace $here $original_version $new_version | relURL)) 0 }}">
-              <span>
-                {{ . }}
-              </span>
-              {{ if $isLatest }}
-              &nbsp;&nbsp;
-              <span class="tag is-small is-success">
-                latest
-              </span>
-              {{ end }}
-            </a>
-            {{ else }}
-            <a class="button is-primary is-outlined has-text-weight-bold"
-               href="{{ index (findRE `^(.*?)\/v\d+.\d+\/` (replace $here $original_version $new_version | relURL)) 0 }}">
-              <span>
-                {{ . }}
-              </span>
-              {{ if $isLatest }}
-              &nbsp;&nbsp;
-              <span class="tag is-small is-success">
-                latest
-              </span>
-              {{ end }}
-            </a>
-            {{ end }}
-            {{- end }}
+              {{/* check if the file we are linking to in the other version exists */ -}}
+              {{ if (fileExists $target_file) -}}
+              <a class="button is-primary is-outlined has-text-weight-bold"
+                href="{{ replace $here $original_version $new_version | relURL }}">
+                <span>{{ . }}</span>
+                {{ if $isLatest -}}
+                  &nbsp;&nbsp;
+                  <span class="tag is-small is-success">latest</span>
+                {{ end -}}
+              </a>
+              {{- else -}}
+              {{/* if not, then link to the top level of that version instead */ -}}
+              {{ if eq "/next/" $new_version -}}
+              <a class="button is-primary is-outlined has-text-weight-bold"
+                href="{{ index (findRE `^(.*?)\/next\/` (replace $here $original_version $new_version | relURL)) 0 }}">
+                <span>{{ . }}</span>
+                {{ if $isLatest -}}
+                  &nbsp;&nbsp;
+                  <span class="tag is-small is-success">
+                    latest
+                  </span>
+                {{ end -}}
+              </a>
+              {{- else -}}
+              <a class="button is-primary is-outlined has-text-weight-bold"
+                href="{{ index (findRE `^(.*?)\/v\d+.\d+\/` (replace $here $original_version $new_version | relURL)) 0 }}">
+                <span>{{ . }}</span>
+                {{ if $isLatest -}}
+                  &nbsp;&nbsp;
+                  <span class="tag is-small is-success">
+                    latest
+                  </span>
+                {{ end -}}
+              </a>
+              {{- end -}}
+              {{ end -}}
 
-            {{ end }}
+            {{ end -}}
           </div>
         </div>
       </div>

--- a/layouts/partials/docs/listing.html
+++ b/layouts/partials/docs/listing.html
@@ -1,4 +1,4 @@
-{{ $docsSections := where .Site.Sections "Section" "docs" }}
+{{ $docsSections := where .Site.Sections "Section" "docs" -}}
 <section class="section has-background-white-bis">
   <p class="is-size-3 is-size-4-mobile has-text-weight-bold">
     The etcd docs
@@ -8,39 +8,35 @@
 
   <div class="columns is-multiline">
     {{ range $docsSections }}
-    <div class="column is-one-third">
-      <a class="is-size-4" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
+      <div class="column is-one-third">
+        <a class="is-size-4" href="{{ .RelPermalink }}">
+          {{ .Title }}
+        </a>
 
-      <ul>
-        {{ range .Pages }}
-        <li>
-          <a>
+        <ul>
+          {{ range .Pages }}
+            <li>
+              <a>{{ .Title }}</a>
+            </li>
+          {{ end }}
+        </ul>
+      </div>
+
+      {{ range .Sections }}
+        <div class="column">
+          <a class="is-size-4" href="{{ .RelPermalink }}">
             {{ .Title }}
           </a>
-        </li>
-        {{ end }}
-      </ul>
-    </div>
 
-    {{ range .Sections }}
-    <div class="column">
-      <a class="is-size-4" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
-
-      <ul>
-        {{ range .Pages }}
-        <li>
-          <a>
-            {{ .Title }}
-          </a>
-        </li>
-        {{ end }}
-      </ul>
-    </div>
-    {{ end }}
-    {{ end }}
+          <ul>
+            {{ range .Pages }}
+              <li>
+                <a>{{ .Title }}</a>
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+      {{ end -}}
+    {{ end -}}
   </div>
 </section>

--- a/layouts/partials/docs/nav-panel.html
+++ b/layouts/partials/docs/nav-panel.html
@@ -1,15 +1,14 @@
-{{ $logo       := site.Params.logos.panel }}
-{{ $currentUrl := .RelPermalink }}
-{{ $editUrl    := printf "https://github.com/etcd-io/website/edit/master/content/%s" .File.Path }}
-{{ $latest     := site.Params.versions.latest }}
-{{ $ghUrl      := printf "https://github.com/etcd-io/etcd/releases/tag/v%s" $latest }}
-{{ $version    := index (split .RelPermalink "/") 2 }}
-{{ $allDocs    := where site.Sections "Section" "docs" }}
+{{ $currentUrl := .RelPermalink -}}
+{{ $editUrl    := printf "https://github.com/etcd-io/website/edit/master/content/%s" .File.Path -}}
+{{ $latest     := site.Params.versions.latest -}}
+{{ $ghUrl      := printf "https://github.com/etcd-io/etcd/releases/tag/v%s" $latest -}}
+{{ $version    := index (split $currentUrl "/") 2 -}}
+{{ $allDocs    := where site.Sections "Section" "docs" -}}
 
 <div class="dashboard-panel is-medium has-background-white-bis is-hidden-mobile">
   <div class="dashboard-panel-header has-text-centered">
     <a href="{{ .Site.BaseURL }}">
-      <img class="is-panel-logo" src="{{ $logo }}">
+      <img class="is-panel-logo" src="{{ site.Params.logos.panel }}">
     </a>
 
     <br /><br />
@@ -18,9 +17,7 @@
       <div class="dropdown-trigger">
         <button class="button is-danger is-radiusless">
           <span>
-            <strong>
-              {{ $version | default "Version" }}
-            </strong>
+            <strong>{{ $version | default "Version" }}</strong>
           </span>
           <span class="icon is-small">
             <i class="fas fa-angle-down" aria-hidden="true"></i>
@@ -31,31 +28,30 @@
       <div class="dropdown-menu">
         <div class="dropdown-content">
 
-          {{ $current_file := .File }}
+          {{ $current_file := .File -}}
 
-          {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
-          {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest | relURL }}
+          {{ $original_version := printf "/%s/" .CurrentSection.Params.version -}}
+          {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest | relURL -}}
 
-          {{ range .Site.Params.versions.all }}
-          {{ $new_version := printf "/%s/" . }}
-          {{ $target_file := replace $current_file $original_version $new_version }}
+          {{ range .Site.Params.versions.all -}}
+            {{ $new_version := printf "/%s/" . -}}
+            {{ $target_file := replace $current_file $original_version $new_version -}}
 
-          {{/* check if the file we are linking to in the other version exists */}}
-          {{ if (fileExists $target_file) -}}
-          <a class="dropdown-item"
-             href="{{ replace $currentUrl $original_version $new_version | relURL }}">{{ . }}</a>
-          {{ else }}
-          {{/* if not, then link to the top level of that version instead */}}
-          {{ if eq "/next/" $new_version }}
-          <a class="navbar-item"
-             href="{{ index (findRE `^(.*?)\/next\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
-          {{ else }}
-          <a class="navbar-item"
-             href="{{ index (findRE `^(.*?)\/v\d+.\d+\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
-          {{ end }}
-          {{- end }}
-          {{ end }}
-
+            {{/* check if the file we are linking to in the other version exists */ -}}
+            {{ if (fileExists $target_file) -}}
+            <a class="dropdown-item"
+              href="{{ replace $currentUrl $original_version $new_version | relURL }}">{{ . }}</a>
+            {{ else -}}
+            {{/* if not, then link to the top level of that version instead */ -}}
+            {{ if eq "/next/" $new_version -}}
+            <a class="navbar-item"
+              href="{{ index (findRE `^(.*?)\/next\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
+            {{ else -}}
+            <a class="navbar-item"
+              href="{{ index (findRE `^(.*?)\/v\d+.\d+\/` (replace $currentUrl $original_version $new_version | relURL)) 0 }}">{{ . }}</a>
+            {{ end -}}
+            {{ end -}}
+          {{ end -}}
         </div>
       </div>
 
@@ -70,41 +66,42 @@
       </a>
       {{ end -}}
 
-      {{ range $allDocs }}
-      {{ range .Sections }}
-      {{ range .RegularPages }}
-      {{ if .Title }}
-      {{ $docVersion := index (split .File.Path "/") 1 }}
-      {{ if eq $docVersion $version }}
-      {{ $isCurrentPage := eq .RelPermalink $currentUrl }}
-      <a class="docs-panel-page{{ if $isCurrentPage }} is-active{{ end }}" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
-      {{ end }}
-      {{ end }}
+      {{ range $allDocs -}}
+        {{ range .Sections -}}
+
+          {{ range .RegularPages -}}
+            {{ if .Title -}}
+              {{ $docVersion := index (split .File.Path "/") 1 -}}
+              {{ if eq $docVersion $version -}}
+                {{ $isCurrentPage := eq .RelPermalink $currentUrl -}}
+                <a class="docs-panel-page{{ if $isCurrentPage }} is-active{{ end }}" href="{{ .RelPermalink }}">
+                  {{ .Title -}}
+                </a>
+              {{ end -}}
+            {{ end -}}
+          {{ end -}}
 
 
-      {{ range .Sections }}
-      {{ $docVersion := index (split .File.Path "/") 1 }}
-      {{ if eq $docVersion $version }}
-      {{ $isCurrentSection := eq .RelPermalink $currentUrl }}
-      <a class="docs-panel-section{{ if $isCurrentSection }} is-active{{ end }}" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
+          {{ range .Sections -}}
+            {{ $docVersion := index (split .File.Path "/") 1 -}}
+            {{ if eq $docVersion $version -}}
+              {{ $isCurrentSection := eq .RelPermalink $currentUrl -}}
+              <a class="docs-panel-section{{ if $isCurrentSection }} is-active{{ end }}" href="{{ .RelPermalink }}">
+                {{ .Title -}}
+              </a>
 
-      {{ range .Pages }}
-      {{ if .Title }}
-      {{ $isCurrentPage := eq .RelPermalink $currentUrl }}
-      <a class="docs-panel-page{{ if $isCurrentPage }} is-active{{ end }}" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
-      {{ end }}
-      {{ end }}
-      {{ end }}
-      {{ end }}
-      {{ end }}
+              {{ range .Pages -}}
+                {{ if .Title -}}
+                  {{ $isCurrentPage := eq .RelPermalink $currentUrl -}}
+                  <a class="docs-panel-page{{ if $isCurrentPage }} is-active{{ end }}" href="{{ .RelPermalink }}">
+                    {{ .Title -}}
+                  </a>
+                {{ end -}}
+              {{ end -}}
+            {{ end -}}
+          {{ end -}}
+        {{ end -}}
+      {{ end -}}
     </div>
   </div>
 

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -1,7 +1,7 @@
-{{ $home     := site.BaseURL }}
-{{ $logo     := site.Params.logos.navbar }}
-{{ $allDocs  := where site.Sections ".Section" "docs" }}
-{{ $latest   := site.Params.versions.latest }}
+{{ $home     := site.BaseURL -}}
+{{ $logo     := site.Params.logos.navbar -}}
+{{ $allDocs  := where site.Sections ".Section" "docs" -}}
+{{ $latest   := site.Params.versions.latest -}}
 <nav class="navbar is-hidden-tablet">
   <div class="navbar-brand">
     <a class="navbar-item" href="{{ $home }}">
@@ -30,13 +30,13 @@
       </p>
 
       {{ range $allDocs }}
-      {{ range .Sections }}
-      {{ range .Sections }}
-      <a class="navbar-item is-indented is-small" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
-      {{ end }}
-      {{ end }}
+        {{ range .Sections }}
+          {{ range .Sections }}
+            <a class="navbar-item is-indented is-small" href="{{ .RelPermalink }}">
+              {{- .Title -}}
+            </a>
+          {{ end }}
+        {{ end }}
       {{ end }}
     </div>
   </div>

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -1,12 +1,11 @@
-{{ $toc := .TableOfContents }}
-{{ with $toc }}
+{{ with .TableOfContents -}}
 <div class="toc dashboard-panel is-small has-background-black is-hidden-touch is-scrollable">
   <p class="toc-title">
-    {{ $.Title }}
+    {{- $.Title -}}
   </p>
 
   <div class="toc-content">
     {{ . }}
   </div>
 </div>
-{{ end }}
+{{ end -}}

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,10 +1,10 @@
-{{ $versions := site.Params.versions.all }}
+{{ $versions := site.Params.versions.all -}}
 <ul>
   {{ range $versions }}
   <li>
     <a href="/docs/{{ . }}">
-      {{ . }}
+      {{- . -}}
     </a>
   </li>
-  {{ end }}
+  {{ end -}}
 </ul>


### PR DESCRIPTION
- Motivation: excess whitespace makes it more difficult to examine and diff generated site files.
- This cleanup generates exactly the same minified site files as before.
- Precursor to #181 work

/tag cleanup
/reviewer @nate-double-u 

```console
$ hugo --cleanDestinationDir -e dev -DFE
...
$ cd ../etcd-io-website.g/ && git diff -bw --ignore-blank-lines
# No diffs
```