### PR TITLE
Update .editorconfig: enforce trimming whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ insert_final_newline = true
 [Makefile]
 indent_style = tab
 
-[*.{html,js,json,md,sass,yaml}]
+[*.{html,js,json,md,css,sass,scss,yaml,yml}]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Even for `.md` files, since we don't use the [two-trailing-whitespace syntax for line breaks][LB] in this site.  If someone needs a linebreak now and again, use `<br>`.

Context: https://github.com/etcd-io/website/pull/204#issuecomment-816319949

/tag cleanup
/reviewer @nate-double-u 

[LB]: https://www.markdownguide.org/basic-syntax#line-breaks