### PR TITLE
Upgrade to Hugo 0.82.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMG = klakegg/hugo:0.81.0-ext-asciidoctor
+DOCKER_IMG = klakegg/hugo:ext-alpine
 DRAFT_ARGS = --buildDrafts --buildFuture  --buildExpired
 
 production-build:

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "npm run production-build"
 
 [build.environment]
-HUGO_VERSION = "0.81.0"
+HUGO_VERSION = "0.82.0"
 
 [context.deploy-preview]
 command = "npm run preview-build"


### PR DESCRIPTION
Hugo 0.82.0 supports:

- Custom Markdown attributes (e.g. CSS classes) for code fences 
- Use of attribute lists in title render hooks

For details, see https://gohugo.io/news/0.82.0-relnotes.

Closes #211

---

Aside from the Hugo version embedded in pages, the generated site files are unchanged.

/tag infrastructure
/reviewer @nate-double-u 