### PR TITLE
Adjust titles, weights and landing pages for docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,7 +146,7 @@ all    = ["next", "v3.4", "v3.3", "v3.2", "v3.1", "v2.3"]
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
@@ -228,3 +228,12 @@ baseName = "_redirects"
 
 [outputs]
 home = ["HTML", "REDIRECTS"]
+
+[menu]
+  [[menu.main]]
+    name = "Docs"
+    url = "/docs/latest/"
+    weight = -10
+  [[menu.main]]
+    name = "Blog"
+    url = "/blog/"

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,8 +1,5 @@
 ---
 title: The etcd blog
-linkTitle: "Blog"
+linkTitle: Blog
 description: News, updates, release announcements, and more
-menu:
-  main:
-    weight: 30
 ---

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,9 +1,8 @@
 ---
-title: The etcd documentation
+title: Documentation versions
+linkTitle: Versions
+simple_list: true
+# TODO(chalin): disable breadcrumbs for this page
 ---
 
-Welcome to the docs for etcd! The following versions are available:
-
-<!-- TODO: Replace versions shortcode -->
-<!-- {{ < versions > }} -->
-
+Welcome to the docs for etcd! The following doc versions are available:

--- a/content/en/docs/next/_index.md
+++ b/content/en/docs/next/_index.md
@@ -1,8 +1,10 @@
 ---
-title: etcd next version
-weight: 1000
+title: Next docs
 cascade:
   version: next
+linkTitle: next
+# Weight for doc version vX.Y should be -XY0. For example, v3.4 has weight -340.
+weight: -1000
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications for the _upcoming_ [etcd version](https://github.com/etcd-io/etcd/).

--- a/content/en/docs/v2.3/_index.md
+++ b/content/en/docs/v2.3/_index.md
@@ -1,7 +1,10 @@
 ---
-title: etcd version 2.3
+title: v2.3 docs
 cascade:
-  version: v2.3
+  version: &vers v2.3
+linkTitle: *vers
+simple_list: true
+weight: -230
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/en/docs/v3.1/_index.md
+++ b/content/en/docs/v3.1/_index.md
@@ -1,7 +1,10 @@
 ---
-title: etcd version 3.1
+title: v3.1 docs
 cascade:
-  version: v3.1
+  version: &vers v3.1
+linkTitle: *vers
+simple_list: true
+weight: -310
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/en/docs/v3.2/_index.md
+++ b/content/en/docs/v3.2/_index.md
@@ -1,7 +1,10 @@
 ---
-title: etcd version 3.2
+title: v3.2 docs
 cascade:
-  version: v3.2
+  version: &vers v3.2
+linkTitle: *vers
+simple_list: true
+weight: -320
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in your applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/content/en/docs/v3.3/_index.md
+++ b/content/en/docs/v3.3/_index.md
@@ -1,5 +1,8 @@
 ---
-title: etcd version 3.3
+title: v3.3 docs
 cascade:
-  version: v3.3
+  version: &vers v3.3
+linkTitle: *vers
+simple_list: true
+weight: -330
 ---

--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -1,11 +1,10 @@
 ---
-title: etcd version 3.4
-linkTitle: Docs
+title: v3.4 docs
 cascade:
-  version: v3.4
-menu:
-  main:
-    weight: 20
+  version: &vers v3.4
+linkTitle: *vers
+simple_list: true
+weight: -340
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.


### PR DESCRIPTION
A proposal for #178

/tag docsy
/milestone 21Q2-docsy
/reviewer @nate-double-u 

---

### Screenshots

Doc versions landing page:

> ![image](https://user-images.githubusercontent.com/4140793/114456317-b6e2e200-9baa-11eb-947e-70389dad1d49.png)

v3.4 docs, using a compact listing for the section content listing:

> ![image](https://user-images.githubusercontent.com/4140793/114456896-66b84f80-9bab-11eb-9aa7-6b7f0f36e109.png)

For sake of comparison, here are the Next docs, using the default format for listing the section content (top portion of the page):

> ![image](https://user-images.githubusercontent.com/4140793/114457078-9d8e6580-9bab-11eb-98f8-c2cd31d77689.png)


