### PR TITLE
Show next version name as v3.5-DRAFT

### DIFF
--- a/content/docs/next/_index.md
+++ b/content/docs/next/_index.md
@@ -1,10 +1,10 @@
 ---
-title: Next docs
+title: v3.5-DRAFT docs
 cascade:
   version: next
-linkTitle: next
-# Weight for doc version vX.Y should be -XY0. For example, v3.4 has weight -340.
-weight: -1000
+  versName: &name v3.5-DRAFT
+linkTitle: *name
+weight: -350 # Weight for doc version vX.Y should be -XY0
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications for the _upcoming_ [etcd version](https://github.com/etcd-io/etcd/).

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -38,6 +38,8 @@
             {{ range $vers := .Site.Params.versions.all }}
 
               {{ $versURI := printf "/%s/" $vers -}}
+              {{ $versPath := printf "/docs/%s/" $vers -}}
+              {{ $versName := ($.GetPage $versPath).Params.versName | default $vers -}}
               {{ $targetFile := replace $thisFile $thisVersURI $versURI -}}
               {{ $targetURL := replace $thisURL $thisVersURI $versURI | relURL -}}
               {{ $isLatest := eq $latest $vers -}}
@@ -48,7 +50,7 @@
               {{ if and $thisVers (fileExists $targetFile) -}}
               <a class="button is-primary is-outlined has-text-weight-bold"
                 href="{{ $targetURL }}">
-                <span>{{ $vers }}</span>
+                <span>{{ $versName }}</span>
                 {{ if $isLatest -}}
                   &nbsp;&nbsp;
                   <span class="tag is-small is-success">latest</span>
@@ -57,7 +59,7 @@
               {{- else -}}
               <a class="button is-primary is-outlined has-text-weight-bold"
                 href="/docs/{{ $vers }}/">
-                <span>{{ $vers }}</span>
+                <span>{{ $versName }}</span>
                 {{ if $isLatest -}}
                   &nbsp;&nbsp;
                   <span class="tag is-small is-success">

--- a/layouts/partials/docs/nav-panel.html
+++ b/layouts/partials/docs/nav-panel.html
@@ -1,6 +1,7 @@
 {{ $thisFile  := .File -}}
 {{ $thisURL   := .RelPermalink -}}
-{{ $thisVers  := .CurrentSection.Params.version -}}
+{{ $thisVers  := .Params.version -}}
+{{ $thisVersName := .Params.versName | default $thisVers -}}
 {{ $editUrl    := printf "https://github.com/etcd-io/website/edit/master/content/%s" .File.Path -}}
 {{ $latest     := site.Params.versions.latest -}}
 {{ $ghUrl      := printf "https://github.com/etcd-io/etcd/releases/tag/v%s" $latest -}}
@@ -18,7 +19,7 @@
       <div class="dropdown-trigger">
         <button class="button is-danger is-radiusless">
           <span>
-            <strong>{{ $thisVers | default "Version" }}</strong>
+            <strong>{{ $thisVersName | default "Version" }}</strong>
           </span>
           <span class="icon is-small">
             <i class="fas fa-angle-down" aria-hidden="true"></i>
@@ -32,6 +33,8 @@
           {{ $thisVersURI := printf "/%s/" $thisVers -}}
 
           {{ range $vers := .Site.Params.versions.all -}}
+            {{ $versPath := printf "/docs/%s/" $vers -}}
+            {{ $versName := ($.GetPage $versPath).Params.versName | default $vers -}}
             {{ $versURI := printf "/%s/" $vers -}}
             {{ $targetFile := replace $thisFile $thisVersURI $versURI -}}
             {{ $targetURL := replace $thisURL $thisVersURI $versURI | relURL -}}
@@ -39,10 +42,10 @@
             {{/* Link to corresponding page under the docs $versURI, if it exists; otherwise link to the new version landing page */ -}}
             {{ if and $thisVers (fileExists $targetFile) -}}
             <a class="dropdown-item"
-              href="{{ $targetURL }}">{{ $vers }}</a>
+              href="{{ $targetURL }}">{{ $versName }}</a>
             {{ else -}}
               <a class="dropdown-item"
-              href="/docs/{{ $vers }}/">{{ $vers }}</a>
+              href="{{ $versPath }}">{{ $versName }}</a>
             {{ end -}}
           {{ end -}}
         </div>

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,10 +1,12 @@
 {{ $versions := site.Params.versions.all -}}
 <ul>
-  {{ range $versions }}
-  <li>
-    <a href="/docs/{{ . }}">
-      {{- . -}}
-    </a>
-  </li>
+  {{ range $vers := $versions }}
+    {{ $versPath := printf "/docs/%s/" $vers -}}
+    {{ $versName := ($.Site.GetPage $versPath).Params.versName | default $vers -}}
+    <li>
+      <a href="{{ $versPath }}">
+        {{- $versName -}}
+      </a>
+    </li>
   {{ end -}}
 </ul>


### PR DESCRIPTION
- Contributes to #220
- Notes:
  - The path to next pages is still `/next/`
  - In the Versions dropdown menu and versions list at the top of the page, we show **v3.5-DRAFT**

Preview, for example: https://deploy-preview-226--etcd.netlify.app/docs/next/

/reviewer @spzala @nate-double-u 

### Screenshot of `/docs/next/`

> ![image](https://user-images.githubusercontent.com/4140793/114888759-86cc5680-9dd7-11eb-9af7-f508121b886f.png)

---

This PR changes no more than the version name for next pages, and it adds trailing `/` to doc versions links from the docs version page (https://deploy-preview-226--etcd.netlify.app/docs/):

```console
$ cd ../etcd-io-website.g/ && git diff -I "[Nn]ext|v3.5-DRAFT"
```
```diff
diff --git a/docs/index.html b/docs/index.html
index 4fa3a573..5e8029d7 100644
--- a/docs/index.html
+++ b/docs/index.html
@@ -282,29 +282,29 @@ ga('send', 'pageview');
         <p>Welcome to the docs for etcd! The following doc versions are available:</p>
 <ul>
   
-  <li>
-    <a href="/docs/next">next</a>
-  </li>
+    <li>
+      <a href="/docs/next/">v3.5-DRAFT</a>
+    </li>
   
-  <li>
-    <a href="/docs/v3.4">v3.4</a>
-  </li>
+    <li>
+      <a href="/docs/v3.4/">v3.4</a>
+    </li>
   
-  <li>
-    <a href="/docs/v3.3">v3.3</a>
-  </li>
+    <li>
+      <a href="/docs/v3.3/">v3.3</a>
+    </li>
   
-  <li>
-    <a href="/docs/v3.2">v3.2</a>
-  </li>
+    <li>
+      <a href="/docs/v3.2/">v3.2</a>
+    </li>
   
-  <li>
-    <a href="/docs/v3.1">v3.1</a>
-  </li>
+    <li>
+      <a href="/docs/v3.1/">v3.1</a>
+    </li>
   
-  <li>
-    <a href="/docs/v2.3">v2.3</a>
-  </li>
+    <li>
+      <a href="/docs/v2.3/">v2.3</a>
+    </li>
   </ul>
 <hr />
         </div>
```