### PR TITLE
Drop About from docsy MVP, and make link checker happy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -230,13 +230,13 @@ baseName = "_redirects"
 home = ["HTML", "REDIRECTS"]
 
 [menu]
-  [[menu.main]]
-    name = "About"
-    url = "/about/"
-    weight = -20
+  # [[menu.main]]
+  #   name = "About"
+  #   url = "/about/"
+  #   weight = -20
   [[menu.main]]
     name = "Docs"
-    url = "/docs/latest/"
+    url = "/docs/v3.4/" # FIXME(chalin): workaround to make link checker happy. Change back to latest
     weight = -10
   [[menu.main]]
     name = "Blog"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -19,7 +19,7 @@ features:
   A distributed, reliable key-value store for the most critical data of a distributed system
 </h2>
 <div class="mt-5 mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/latest/" data-proofer-ignore>
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/" data-proofer-ignore>
 		Docs<i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/etcd-io/etcd">
@@ -37,7 +37,7 @@ features:
     elections during network partitions and can tolerate machine failure, even
     in the leader node.
   </p>
-  <a href="/about/">Learn more<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
+  <a href="/docs/{{< param versions.latest >}}/">Learn more<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
 {{% /blocks/lead %}}
 
 <div class="container">

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -19,7 +19,7 @@ features:
   A distributed, reliable key-value store for the most critical data of a distributed system
 </h2>
 <div class="mt-5 mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/" data-proofer-ignore>
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/">
 		Docs<i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/etcd-io/etcd">


### PR DESCRIPTION
- As agreed via Slack, this removes any link to the new **About** page (while keeping the page for evaluation later when we start bringing in the new IA)
- Eliminate `/latest/` links
  - On the homepage: instead link directly to the param `versions.latest` (this is the `docsy` branch port of #221)
  - In the top-nav: temporarily using `v3.4` instead. I've added a FIXME tag to ensure that we revert this change later.

I can confirm that the link checker is now happy:

```console
$ htmltest
htmltest started at 11:03:28 on public
========================================================================
✔✔✔ passed in 1.417652379s
tested 401 documents
```

/tag docsy
/milestone 21Q2-docsy
/reviewer @nate-double-u 