### PR TITLE
Add page warning for all doc version pages other than latest

### DIFF
--- a/assets/scss/_alerts.scss
+++ b/assets/scss/_alerts.scss
@@ -1,0 +1,20 @@
+/* etcd-docsy file override */
+
+.td-alert {
+    font-weight: $font-weight-medium;
+    background: $white;
+    color: inherit;
+    border-radius: 0;
+
+    @each $color, $value in $theme-colors {
+        &-#{$color} {
+            & .alert-heading {
+                color: $value;
+            }
+
+            border-style: solid;
+            border-color: $value;
+            border-width: 0 0 0 4px;
+        }
+    }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -118,6 +118,12 @@
   }
 }
 
+// Bootstrap and Docsy overrides
+
+.alert > p:last-child {
+  margin-bottom: 0;
+}
+
 // Utilities
 
 .bg-gray-100 {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -13,9 +13,12 @@ $enable-rounded: false;
 // // TODO: add value checks later in the import chain
 
 // $_font-weight-light: 300;
+$_yellow:  #ffc107;
 
 // // Display styles: prefer Bootstrap defaults to Docsy's overrides
 // $display1-weight: $_font-weight-light;
 // $display2-weight: $_font-weight-light;
 // $display3-weight: $_font-weight-light;
 // $display4-weight: $_font-weight-light;
+
+$warning: $_yellow; // Use Bootstrap default

--- a/config.toml
+++ b/config.toml
@@ -139,6 +139,8 @@ version_menu = "Versions"
 [params.versions]
 latest = "v3.4"
 all    = ["next", "v3.4", "v3.3", "v3.2", "v3.1", "v2.3"]
+deprecation_warning = """the documentation is no longer actively maintained.
+  The page that you are viewing is the last archived version."""
 
 # User interface configuration
 [params.ui]

--- a/content/en/docs/next/_index.md
+++ b/content/en/docs/next/_index.md
@@ -3,6 +3,7 @@ title: v3.5-DRAFT docs
 cascade:
   version: next
   versName: &name v3.5-DRAFT
+  page_warning: the documentation is in **DRAFT** status.
 linkTitle: *name
 simple_list: true
 weight: -350 # Weight for doc version vX.Y should be -XY0

--- a/content/en/docs/v2.3/_index.md
+++ b/content/en/docs/v2.3/_index.md
@@ -2,6 +2,7 @@
 title: v2.3 docs
 cascade:
   version: &vers v2.3
+  is_deprecated: true
 linkTitle: *vers
 simple_list: true
 weight: -230

--- a/content/en/docs/v3.1/_index.md
+++ b/content/en/docs/v3.1/_index.md
@@ -2,6 +2,7 @@
 title: v3.1 docs
 cascade:
   version: &vers v3.1
+  is_deprecated: true
 linkTitle: *vers
 simple_list: true
 weight: -310

--- a/content/en/docs/v3.2/_index.md
+++ b/content/en/docs/v3.2/_index.md
@@ -2,6 +2,7 @@
 title: v3.2 docs
 cascade:
   version: &vers v3.2
+  is_deprecated: true
 linkTitle: *vers
 simple_list: true
 weight: -320

--- a/content/en/docs/v3.3/_index.md
+++ b/content/en/docs/v3.3/_index.md
@@ -2,6 +2,7 @@
 title: v3.3 docs
 cascade:
   version: &vers v3.3
+  is_deprecated: true
 linkTitle: *vers
 simple_list: true
 weight: -330

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,30 @@
+{{/* etcd-docsy file override */ -}}
+
+{{ if .Params.is_deprecated | or .Params.page_warning -}}
+  {{ $pageWarning := .Params.page_warning | default .Site.Params.versions.deprecation_warning -}}
+  {{ $thisFile  := .File -}}
+  {{ $thisURL   := .RelPermalink -}}
+  {{ $thisVers  := .Params.version -}}
+  {{ $thisVersName := .Params.versName | default $thisVers -}}
+  {{ $thisVersURI := printf "/%s/" $thisVers -}}
+
+  {{ $vers := .Site.Params.versions.latest -}}
+  {{ $versURI := printf "/%s/" $vers -}}
+  {{ $versPath := printf "/docs/%s/" $vers -}}
+
+  {{ $targetFile := replace $thisFile $thisVersURI $versURI -}}
+  {{ $targetURL := replace $thisURL $thisVersURI $versURI | relURL -}}
+  {{ if not (and $thisVers (fileExists $targetFile)) -}}
+    {{ $targetURL = $versPath -}}
+  {{ end -}}
+
+  {{ $color := "warning" -}}
+  <div class="alert alert-warning" role="alert">
+    <p>Version <strong>{{ $thisVersName }}</strong> of
+    {{ $pageWarning | markdownify }}
+    For the latest stable documentation, see
+    <a href="{{ $targetURL }}">
+      {{- $vers -}}
+    </a>.</p>
+  </div>
+{{ end }}


### PR DESCRIPTION
- Closes #236
  - Next pages give a _**DRAFT** status_ warning
  - Deprecated doc version pages show a deprecation warning.
- In terms of style I opted for a standard Bootstrap alert-warning.

### Screenshots

> ![image](https://user-images.githubusercontent.com/4140793/114928507-acba2100-9e00-11eb-98db-2fb9e682489a.png)

> ![image](https://user-images.githubusercontent.com/4140793/114928884-20f4c480-9e01-11eb-866f-f1df2541a2db.png)

/tag docsy
/milestone 21Q2-docsy
/reviewer @nate-double-u 