### PR TITLE
Reenable analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 languageCode = "en-us"
+googleAnalytics = "UA-82811140-29"
 
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
@@ -33,12 +34,6 @@ pygmentsStyle = "fruity" # "tango"
 resampleFilter = "CatmullRom"
 quality = 75
 anchor = "smart"
-
-[services]
-[services.googleAnalytics]
-# Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-# TODO: re-enable tracking code after dev/testing
-# id = "UA-82811140-29"
 
 # Language configuration
 


### PR DESCRIPTION
Note that this also activates the docsy feedback feature (which I'd prefer not bring in right now, but I haven't found a quick and easy way to disable, and so will leave it in).

/tag docsy
/milestone post-docsy
/reviewer @nate-double-u 