### PR TITLE
Updating author frontmatter format

### DIFF
--- a/content/en/blog/2020/jepsen-343-results.md
+++ b/content/en/blog/2020/jepsen-343-results.md
@@ -1,8 +1,7 @@
 ---
 title: Latest Jepsen Results against etcd 3.4.3
 date: 2020-01-30
-authors:
-- name: Xiang Li
+author: Xiang Li
 ---
 
 Jepsen tested and analyzed etcd 3.4.3, and had both good results and useful feedback to share with us.


### PR DESCRIPTION
Docsy theme picks up `author` for attribution line. I don't think we'll need to update the template files to sort this issue.

contributes to #247

/cc @chalin 