### PR TITLE
Adding .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+$ cat .gitattributes
+*.0 linguist-documentation
+*.1 linguist-documentation
+*.2 linguist-documentation
+*.3 linguist-documentation
+*.4 linguist-documentation
+*.5 linguist-documentation
+*.6 linguist-documentation
+*.7 linguist-documentation
+*.8 linguist-documentation
+*.9 linguist-documentation
+


### PR DESCRIPTION
Adding *.0 - *.9 classification lines so that GitHub categorizes the languages used in the repo more correctly.

I don't expect we'll know if this works until we merge it into master. If it doesn't sort the issue we can revert the merge.

potentially solves #164

/cc @chalin 