### PR TITLE
Eliminate Hugo warning about .Page.Dir

### DIFF
--- a/layouts/shortcodes/metrics-list.html
+++ b/layouts/shortcodes/metrics-list.html
@@ -1,4 +1,4 @@
-{{ $dir := printf "/content/%s/%s%s" .Page.File.Lang .Page.Dir "metrics" -}}
+{{ $dir := printf "/content/%s/%s%s" .Page.File.Lang .Page.File.Dir "metrics" -}}
 {{ $regexp := .Get "regexp" | default "." -}}
 
 {{ $counter := 0 -}}


### PR DESCRIPTION
- Hugo complains about `.Page.Dir`:

  ```console
  $ hugo
  WARN 2021/04/27 17:39:35 Page.Dir is deprecated and will be removed in a future release. Use .File.Dir
  ```
  
  This small PR addresses the issue.
- There is no change in the generated site files.

/tag infrastructure
/reviewer @nate-double-u 
