### PR TITLE
Config: cleanup and rename default branch to main

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,7 +62,7 @@ params:
 
     # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/etcd-io/website
-  github_branch: master
+  github_branch: main
 
   # An optional link to a related project repo. For example, the sibling repository where your product code lives.
   github_project_repo: https://github.com/etcd-io/etcd

--- a/config.yaml
+++ b/config.yaml
@@ -61,11 +61,11 @@ params:
     distributed system
 
     # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-  github_repo: 'https://github.com/etcd-io/website'
+  github_repo: https://github.com/etcd-io/website
   github_branch: master
 
   # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-  github_project_repo: 'https://github.com/etcd-io/etcd'
+  github_project_repo: https://github.com/etcd-io/etcd
 
   # Enable Algolia DocSearch
   algolia_docsearch: false
@@ -138,21 +138,21 @@ params:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
       - name: Google Group
-        url: 'https://groups.google.com/forum/?hl=en#!forum/etcd-dev'
+        url: https://groups.google.com/forum/?hl=en#!forum/etcd-dev
         icon: fab fa-google
       - name: Twitter
-        url: 'https://twitter.com/etcdio'
+        url: https://twitter.com/etcdio
         icon: fab fa-twitter
       - name: Stack Overflow
-        url: 'https://stackoverflow.com/questions/tagged/etcd'
+        url: https://stackoverflow.com/questions/tagged/etcd
         icon: fab fa-stack-overflow
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: Etcd on GitHub
-        url: 'https://github.com/etcd-io/etcd'
+        url: https://github.com/etcd-io/etcd
         icon: fab fa-github-square
       - name: Etcd.io on GitHub
-        url: 'https://github.com/etcd-io/website'
+        url: https://github.com/etcd-io/website
         icon: fab fa-github
   # [params.logos]
   hero: >-


### PR DESCRIPTION
- Cleanup following #149 
- There is no change in the generated site files except for the rename of the default branch
  ```console
  $ cd ../etcd-io-website.g
  $ find . -type f -name '*.html' -print0 | xargs -0 perl -pi -e 's|blob/main\b|blob/master|g' # did same for edit and new
  $ git diff
  $
  ```