### PR TITLE
Update libraries and tools

### DIFF
--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -41,7 +41,7 @@ description: A listing of etcd tools and client libraries
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
 - [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
-- [mingchuno/etcd4s](https://github.com/mingchuno/etcd4s) - Supports v3 using gRPC under the hood with optional Akka Stream support for stream APIs.
+- [mingchuno/etcd4s](https://github.com/mingchuno/etcd4s) - Supports v3 using gRPC with optional Akka Stream support.
 
 **Perl libraries**
 

--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -41,6 +41,7 @@ description: A listing of etcd tools and client libraries
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
 - [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
+- [mingchuno/etcd4s](https://github.com/mingchuno/etcd4s) - Supports v3 using gRPC under the hood with optional Akka Stream support for stream APIs.
 
 **Perl libraries**
 


### PR DESCRIPTION
Include mingchuno/etcd4s library for Scala with V3 support and watch using Akka Stream.