### PR TITLE
docs/next: update tag to v3.5.0-beta.3

### DIFF
--- a/content/en/docs/next/_index.md
+++ b/content/en/docs/next/_index.md
@@ -3,7 +3,7 @@ title: v3.5-DRAFT docs
 cascade:
   version: next
   versName: &name v3.5-DRAFT
-  git_version_tag: v3.5.0-alpha.0
+  git_version_tag: v3.5.0-beta.3
   page_warning: the documentation is in **DRAFT** status.
 linkTitle: *name
 simple_list: true


### PR DESCRIPTION
Reference: https://github.com/etcd-io/etcd/releases/tag/v3.5.0-beta.3