### PR TITLE
Update v3.4 git_version_tag to v3.4.16

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -2,7 +2,7 @@
 title: v3.4 docs
 cascade:
   version: &vers v3.4
-  git_version_tag: v3.4.15
+  git_version_tag: v3.4.16
 linkTitle: *vers
 simple_list: true
 weight: -340


### PR DESCRIPTION
I double checked that this was the latest:

```console
$ git tag --sort=v:refname | grep v3\.4 | tail -1
v3.4.16
```

Closes #283