### PR TITLE
Homepage CTA buttons: replace GH by Learn more

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -19,11 +19,11 @@ features:
   A distributed, reliable key-value store for the most critical data of a distributed system
 </h2>
 <div class="mt-5 mx-auto">
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/">
+		Learn more
+	</a>
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/quickstart">
 		Quickstart<i class="fas fa-arrow-alt-circle-right ml-2"></i>
-	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/etcd-io/etcd">
-		GitHub <i class="fab fa-github ml-2 "></i>
 	</a>
 </div>
 {{< /blocks/cover >}}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -36,8 +36,8 @@ features:
     distributed system or cluster of machines. It gracefully handles leader
     elections during network partitions and can tolerate machine failure, even
     in the leader node.
+    <a href="/docs/{{< param versions.latest >}}/">Learn more<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
   </p>
-  <a href="/docs/{{< param versions.latest >}}/">Learn more<i class="fas fa-arrow-alt-circle-right ml-2"></i></a>
 {{% /blocks/lead %}}
 
 <div class="container">


### PR DESCRIPTION
- CTA buttons should be just that, call-to-action. We have a link to GH in the footer of every page, so we don't need it to take up a CTA button slot. Instead it makes more sense to link to the latest docs. This PR makes that change and switches the order of the buttons so that Quickstart is second (but keeps its icon so it is more eye-catching the "Learn more" before it).
- In the second section of the page, now that we have a "Learn more" in the hero section, it makes sense to have the "Learn more" that appears there be less prominent (saving homepage vertical real estate).
- UX / navigation contribution to #267