### PR TITLE
Config: add warning that was lost in translation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -176,7 +176,7 @@ outputs:
 menu:
   main:
     - name: Docs
-      url: /docs/v3.4/
+      url: /docs/v3.4/ # FIXME(chalin): workaround to make link checker happy. Change back to latest. For details, see https://github.com/etcd-io/website/issues/307
       weight: -10
     - name: Blog
       url: /blog/


### PR DESCRIPTION
Warning was lost during #254. Adding warning back, as a reminder, with a link to the new issue describing the problem.