### PR TITLE
Link testing using linkinator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linkinator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Wait for Netlify Deployment
+        uses: probablyup/wait-for-netlify-action@3.2.0
+        id: waitForDeployment
+        with:
+          site_id: '4e013eac-b885-4ee5-a808-0b238097d476'
+        env:
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+      - name: Run linkinator
+        uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: ${{ steps.waitForDeployment.outputs.url }}
+          linksToSkip: '^(?!${{ steps.waitForDeployment.outputs.url }})'
+          recurse: true
+          verbosity: "error"
+          retry: true
+          concurrency: 100
+          timeout: 0
+          markdown: false
+          directoryListing: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,3 @@ jobs:
           timeout: 0
           markdown: false
           directoryListing: false
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,4 @@ jobs:
           timeout: 0
           markdown: false
           directoryListing: false
+

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ run-link-checker:
 
 check-links: production-build link-checker-setup run-link-checker
 
-ci-check-links: link-checker-setup run-link-checker
-
 # Adding additional link checks based on https://github.com/grpc/grpc.io/blob/main/Makefile
 check-internal-links: production-build link-checker-setup run-link-checker
 	bin/htmltest --conf .htmltest.yml


### PR DESCRIPTION
Use linkinator and GitHub actions to do a link check after the site builds on Netlify.

https://github.com/JustinBeckwith/linkinator-action
https://github.com/marketplace/actions/wait-for-netlify-deployment

Fixes #307 