### PR TITLE
Reinstate link checking for preview builds

### DIFF
--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -1,4 +1,4 @@
-DirectoryPath: public
+DirectoryPath: public.htmltest
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreURLs: [example.com]

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,4 +1,4 @@
-DirectoryPath: public
+DirectoryPath: public.htmltest
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 CheckExternal: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DOCKER_IMG = klakegg/hugo:ext-alpine
 DRAFT_ARGS = --buildDrafts --buildFuture  --buildExpired
+HTMLTEST?=bin/htmltest
+TESTDIR=public.htmltest
 
 production-build:
 	npm run build:production
@@ -12,7 +14,16 @@ link-checker-setup:
 	curl https://htmltest.wjdp.uk | bash
 
 run-link-checker:
-	bin/htmltest
+	rm -Rf $(TESTDIR)
+	cp -R public $(TESTDIR)
+	# Update values below when latest & next change, or find a dynamic way to fetch the corresponding versions.
+	( \
+		cd $(TESTDIR)/docs; \
+		ln -s next v3.5; \
+		ln -s v3.4 latest; \
+	)
+	$(HTMLTEST)
+	rm -Rf $(TESTDIR)
 
 check-links: production-build link-checker-setup run-link-checker
 

--- a/config.yaml
+++ b/config.yaml
@@ -176,9 +176,9 @@ outputs:
 menu:
   main:
     - name: Docs
-      url: /docs/v3.4/ # FIXME(chalin): workaround to make link checker happy. Change back to latest. For details, see https://github.com/etcd-io/website/issues/307
+      url: /docs/latest/
       weight: -10
     - name: Blog
       url: /blog/
     - name: Install
-      url: /docs/v3.4/install/ # FIXME(Nate W.): workaround to make link checker happy. Change back to latest. For details, see https://github.com/etcd-io/website/issues/307
+      url: /docs/latest/install/

--- a/content/en/docs/v3.4/quickstart.md
+++ b/content/en/docs/v3.4/quickstart.md
@@ -52,7 +52,7 @@ ln -s /tmp/etcd-${ETCD_VER}-darwin-amd64/* $ETCD_BIN
 ```
 
 {{% alert title="Note" color="info" %}}
-To work with the latest version, learn how to [build from the main branch](/docs/{{< param version >}}/dl-build/#build-the-latest-version).
+To work with the latest version, learn how to [build from the main branch](/docs/{{< param version >}}/install/#build-from-source).
 {{% /alert %}}
 
 ## Launch etcd

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "hugo $npm_package_config_DEV_ARGS",
     "check-env": "node -e 'console.log(process.env)' | grep npm",
     "get-submodules": "git submodule update --init --recursive --depth 1",
-    "disable-postbuild:preview": "make ci-check-links",
+    "postbuild:preview": "make ci-check-links",
     "prebuild:preview": "npm run get-submodules && ./check-hugo.sh",
     "prebuild:production": "npm run get-submodules && ./check-hugo.sh",
     "prebuild": "./check-hugo.sh",


### PR DESCRIPTION
This PR allows us to keep using htmltest for now by tricking it into believing our two main path aliases exist (we create symlinks in a copy of the build).