### PR TITLE
Always show Versions menu, though disabled when necessary

### DIFF
--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -25,4 +25,8 @@
       <a class="dropdown-item" href="{{ $targetURL }}">{{ $versName }}</a>
     {{ end -}}
   </div>
+{{ else }}
+  <a class="nav-link dropdown-toggle disabled" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    {{- .Site.Params.version_menu -}}
+  </a>
 {{ end -}}


### PR DESCRIPTION
Now we always display the **Versions** menu but have made it **inactive** on pages where it doesn't apply.

fixes #304.