### PR TITLE
Correcting supported platforms links on Install pages (next & v3.4)

### DIFF
--- a/content/en/docs/next/install.md
+++ b/content/en/docs/next/install.md
@@ -79,4 +79,4 @@ For a slightly more involved sanity check of your installation, see
 [Quickstart]: {{< relref "quickstart" >}}
 [releases]: https://github.com/etcd-io/etcd/releases/
 [tagged-release]: https://github.com/etcd-io/etcd/releases/tag/{{< param git_version_tag >}}
-[Supported platforms]: {{< relref "op-guide/hardware" >}}
+[Supported platforms]: {{< relref "op-guide/supported-platform" >}}

--- a/content/en/docs/v3.4/install.md
+++ b/content/en/docs/v3.4/install.md
@@ -79,4 +79,4 @@ For a slightly more involved sanity check of your installation, see
 [Quickstart]: {{< relref "quickstart" >}}
 [releases]: https://github.com/etcd-io/etcd/releases/
 [tagged-release]: https://github.com/etcd-io/etcd/releases/tag/{{< param git_version_tag >}}
-[Supported platforms]: {{< relref "op-guide/hardware" >}}
+[Supported platforms]: {{< relref "op-guide/supported-platform" >}}


### PR DESCRIPTION
Deploy previews:
- https://deploy-preview-350--etcd.netlify.app/docs/v3.4/install/
- https://deploy-preview-350--etcd.netlify.app/docs/next/install/

fixes #347 