### PR TITLE
Changing the title of v3.4 supported-platforms page to "Supported platforms"

### DIFF
--- a/content/en/docs/v3.4/op-guide/supported-platform.md
+++ b/content/en/docs/v3.4/op-guide/supported-platform.md
@@ -1,5 +1,5 @@
 ---
-title: Supported systems
+title: Supported platforms
 weight: 4800
 description: etcd support status for common architectures & operating systems
 ---


### PR DESCRIPTION
Updating supported platforms (v3.4) page title to match that of the next (v3.5) version

Deploy preview: https://deploy-preview-352--etcd.netlify.app/docs/v3.4/op-guide/supported-platform/

fixes  #351 