### PR TITLE
Removing docs improvement CTA from version landing pages

### DIFF
--- a/content/en/docs/next/_index.md
+++ b/content/en/docs/next/_index.md
@@ -11,9 +11,4 @@ weight: -350 # Weight for doc version vX.Y should be -XY0
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using
-etcd in applications for the _upcoming_ [etcd
-version](https://github.com/etcd-io/etcd/).
-
-Improvements to these docs are encouraged through [pull
-requests](https://help.github.com/en/articles/about-pull-requests) to the
-[etcd-io/website project](https://github.com/etcd-io/website) on GitHub.
+etcd in applications.

--- a/content/en/docs/v2.3/_index.md
+++ b/content/en/docs/v2.3/_index.md
@@ -10,6 +10,4 @@ weight: -230
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using
-etcd in your applications. Improvements to these docs are encouraged through
-[pull requests](https://help.github.com/en/articles/about-pull-requests) to the
-[etcd project](https://github.com/etcd-io/etcd) on GitHub.
+etcd in your applications.

--- a/content/en/docs/v3.1/_index.md
+++ b/content/en/docs/v3.1/_index.md
@@ -10,6 +10,4 @@ weight: -310
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using
-etcd in your applications. Improvements to these docs are encouraged through
-[pull requests](https://help.github.com/en/articles/about-pull-requests) to the
-[etcd project](https://github.com/etcd-io/etcd) on GitHub.
+etcd in your applications.

--- a/content/en/docs/v3.2/_index.md
+++ b/content/en/docs/v3.2/_index.md
@@ -10,6 +10,4 @@ weight: -320
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using
-etcd in your applications. Improvements to these docs are encouraged through
-[pull requests](https://help.github.com/en/articles/about-pull-requests) to the
-[etcd project](https://github.com/etcd-io/etcd) on GitHub.
+etcd in your applications.

--- a/content/en/docs/v3.3/_index.md
+++ b/content/en/docs/v3.3/_index.md
@@ -8,3 +8,6 @@ linkTitle: *vers
 simple_list: true
 weight: -330
 ---
+
+These docs cover everything from setting up and running an etcd cluster to using
+etcd in applications.

--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -9,6 +9,4 @@ weight: -340
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using
-etcd in applications. Improvements to these docs are encouraged through [pull
-requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd
-project](https://github.com/etcd-io/etcd) on GitHub.
+etcd in applications.


### PR DESCRIPTION
Removing docs improvement CTA from version landing pages across all versions.

Deploy previews:
- https://deploy-preview-353--etcd.netlify.app/docs/v3.4/
- https://deploy-preview-353--etcd.netlify.app/docs/v3.3/
- https://deploy-preview-353--etcd.netlify.app/docs/v3.2/
- https://deploy-preview-353--etcd.netlify.app/docs/v3.1/
- https://deploy-preview-353--etcd.netlify.app/docs/v2.3/
- https://deploy-preview-353--etcd.netlify.app/docs/next/

Fixes #300 