### PR TITLE
Preparing site for v3.5 release

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ params:
   # This menu appears only if you have at least one [params.versions] set.
   version_menu: Versions
   versions:
-    latest: v3.4
+    latest: v3.5
     all:
       - v3.5
       - v3.4

--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -3,6 +3,7 @@ title: v3.4 docs
 cascade:
   version: &vers v3.4
   git_version_tag: v3.4.16
+  is_deprecated: true
 linkTitle: *vers
 simple_list: true
 weight: -340

--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -1,10 +1,9 @@
 ---
-title: v3.5-DRAFT docs
+title: v3.5 docs
 cascade:
   version: v3.5
-  versName: &name v3.5-DRAFT
-  git_version_tag: v3.5.0-beta.4
-  page_warning: the documentation is in **DRAFT** status.
+  versName: &name v3.5
+  git_version_tag: v3.5.0
 linkTitle: *name
 simple_list: true
 weight: -350 # Weight for doc version vX.Y should be -XY0


### PR DESCRIPTION
Preparing the site for v3.5 release.
**Not to be merged before Jun 15, 2021 at 6:00 PM EDT.**

* Updating latest #328
* Changing v3.5-DRAFT to v3.5 #377 
* Setting announcement blog draft status to false #376
  * Also removing extra (unneeded) spaces from line ends of announcement file. 
* Setting v3.4 deprecation status

Fixes: #376, #377
Contributes to: #328

## Deploy previews

* https://deploy-preview-379--etcd.netlify.app/blog/2021/announcing-etcd-3.5/
* https://deploy-preview-379--etcd.netlify.app/
* https://deploy-preview-379--etcd.netlify.app/docs/v3.5/
* https://deploy-preview-379--etcd.netlify.app/docs/v3.4/

## Redirect tests

* https://deploy-preview-379--etcd.netlify.app/docs/latest/ (v3.5)
* https://deploy-preview-379--etcd.netlify.app/docs/next/ (v3.5)
* https://deploy-preview-379--etcd.netlify.app/docs/current/ (v3.5)
* https://deploy-preview-379--etcd.netlify.app/docs/latest/quickstart/ (v3.5)
* https://deploy-preview-379--etcd.netlify.app/docs/next/quickstart/ (v3.5)
* https://deploy-preview-379--etcd.netlify.app/docs/current/quickstart/ (v3.5)