### PR TITLE
Updating Generated API References with v3.5 release

### DIFF
--- a/content/en/docs/v3.5/dev-guide/api_concurrency_reference_v3.md
+++ b/content/en/docs/v3.5/dev-guide/api_concurrency_reference_v3.md
@@ -164,5 +164,3 @@ The election service exposes client-side election facilities as a gRPC interface
 | value | value is the value held by the key, in bytes. | bytes |
 | lease | lease is the ID of the lease that attached to key. When the attached lease expires, the key will be deleted. If lease is 0, then no lease is attached to the key. | int64 |
 
-
-

--- a/content/en/docs/v3.5/dev-guide/api_reference_v3.md
+++ b/content/en/docs/v3.5/dev-guide/api_reference_v3.md
@@ -1052,5 +1052,3 @@ User is a single entry in the bucket authUsers
 | ----- | ----------- | ---- |
 | no_password |  | bool |
 
-
-


### PR DESCRIPTION
Updating:
* `content/en/docs/v3.5/dev-guide/api_concurrency_reference_v3.md`
* `content/en/docs/v3.5/dev-guide/api_reference_v3.md`

fixes #380
contributes to #328