### PR TITLE
Adding annotations to v3.5 Table of Contents page

### DIFF
--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -5,7 +5,7 @@ cascade:
   versName: &name v3.5
   git_version_tag: v3.5.0
 linkTitle: *name
-simple_list: true
+simple_list: false
 weight: -350 # Weight for doc version vX.Y should be -XY0
 ---
 


### PR DESCRIPTION
As per issue #65 
>     * Documentation TOC - page with an annotated TOC for the documentation and direct links to important pages.

Adding annotation to the docs index/TOC

Contributes to: #247

Deploy Preview:
* https://deploy-preview-386--etcd.netlify.app/docs/v3.5/