### PR TITLE
add external link icon

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -203,3 +203,16 @@
 #td-content__toc-link-expanded {
   background-color: $gray-200;
 }
+
+// add icon to signify that a link is external
+// from https://fontawesome.com/v5.15/icons/external-link-alt?style=solid
+
+.td-content a[href^="http://"]:after, 
+.td-content a[href^="https://"]:after {
+  font-family: 'Font Awesome\ 5 Free';  
+  content: "\f35d";
+  position: relative;
+  bottom: 1px;
+  padding: 0 3px;
+  font-size: .7rem;
+}


### PR DESCRIPTION
Adds an external link icon from Font Awesome https://fontawesome.com/v5.15/icons/external-link-alt?style=solid to indicate that a link takes the reader to an external site. Only styles the links within docs articles (without the `.td-content` selector, external links in left and right sidebars, as well as breadcrumbs would also inherit this style). 

Fixes https://github.com/etcd-io/website/issues/269