### PR TITLE
add styles to indicate existence of doc for each version

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -216,3 +216,56 @@
   padding: 0 3px;
   font-size: .7rem;
 }
+
+// ************************************
+
+// Styles for icon in version menu
+
+// ************************************
+
+// style options in Versions drop down on the upper right of the docs so that it's clear if a doc exists for a particular version as not all docs exist in all versions
+
+//  establish fontawesome on dropdown:after
+
+a.dropdown-item:after {
+
+  font-family: 'Font Awesome\ 5 Free';  
+  position: relative;
+  bottom: 1px;
+  padding: 0 3px;
+  font-size: .7rem;
+
+}
+
+// Document icon is from https://fontawesome.com/v5.15/icons/file-alt?style=solid and signifies a doc exists in a particular version
+
+a.dropdown-item[href*="/docs/"] {
+  
+  &:hover {
+    background: #a0d0ff linear-gradient(180deg, #1f6897, #1f6897) repeat-x;
+    color: #fff;
+  }
+  
+  &:after {
+    content: "\f15c";
+  }
+}
+
+// Remove the doc icon from the version numbers in the dropdown that don't have a corresponding doc. 
+// ~= means that the href value ends in the string specified. Maintainers will have to add new versions as they come out if there aren't docs for that version.
+a.dropdown-item[href~="/docs/v2.3/"], 
+a.dropdown-item[href~="/docs/v3.1/"], 
+a.dropdown-item[href~="/docs/v3.2/"], 
+a.dropdown-item[href~="/docs/v3.3/"], 
+a.dropdown-item[href~="/docs/v3.4/"],
+a.dropdown-item[href~="/docs/v3.5/"] {
+
+  &:hover {
+    background:#accff3 linear-gradient(180deg, #deeaf7, #e3ecf5) repeat-x;
+    color: #222;
+  }
+  
+  &:after {
+    content: "";
+  }
+}


### PR DESCRIPTION
Contributes to #296

Adds icons showing that a doc exists or that a doc doesn't for each version. Used an icon for accessibility in case of color blindness or other visual issues where color isn't a sufficient indicator.


## Hover state and icon for non-existent doc
<img width="137" alt="Screen Shot 2021-06-22 at 3 53 28 PM" src="https://user-images.githubusercontent.com/4116963/122990510-06dfe100-d372-11eb-95e0-184e420402cb.png">

## Hover state and icon for existent doc
<img width="133" alt="Screen Shot 2021-06-22 at 3 53 32 PM" src="https://user-images.githubusercontent.com/4116963/122990527-0a736800-d372-11eb-8b67-531ca28077e7.png">

Another option is that we dispense with the no-doc icon and keep the file icon. That might be enough. Also, maybe there's a better way to select the href attribute allowing for variance.
