### PR TITLE
Rename master branch to mian branch

### DIFF
--- a/content/en/docs/v3.5/branch_management.md
+++ b/content/en/docs/v3.5/branch_management.md
@@ -7,7 +7,7 @@ description: etcd branch management
 ## Guide
 
 * New development occurs on the [main branch][main].
-* Master branch should always have a green build!
+* Main branch should always have a green build!
 * Backwards-compatible bug fixes should target the master branch and subsequently be ported to stable branches.
 * Once the master branch is ready for release, it will be tagged and become the new stable branch.
 

--- a/content/en/docs/v3.5/branch_management.md
+++ b/content/en/docs/v3.5/branch_management.md
@@ -6,7 +6,7 @@ description: etcd branch management
 
 ## Guide
 
-* New development occurs on the [master branch][master].
+* New development occurs on the [main branch][main].
 * Master branch should always have a green build!
 * Backwards-compatible bug fixes should target the master branch and subsequently be ported to stable branches.
 * Once the master branch is ready for release, it will be tagged and become the new stable branch.
@@ -27,5 +27,5 @@ All branches with prefix `release-` are considered _stable_ branches.
 
 After every minor release ([semver.org](https://semver.org/)), we will have a new stable branch for that release, managed by a [patch release manager](./dev-internal/release#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
 
-[master]: https://github.com/etcd-io/etcd/tree/master
+[main]: https://github.com/etcd-io/etcd/tree/main
 

--- a/content/en/docs/v3.5/branch_management.md
+++ b/content/en/docs/v3.5/branch_management.md
@@ -8,16 +8,16 @@ description: etcd branch management
 
 * New development occurs on the [main branch][main].
 * Main branch should always have a green build!
-* Backwards-compatible bug fixes should target the master branch and subsequently be ported to stable branches.
-* Once the master branch is ready for release, it will be tagged and become the new stable branch.
+* Backwards-compatible bug fixes should target the main branch and subsequently be ported to stable branches.
+* Once the main branch is ready for release, it will be tagged and become the new stable branch.
 
 The etcd team has adopted a *rolling release model* and supports two stable versions of etcd.
 
-### Master branch
+### Main branch
 
-The `master` branch is our development branch. All new features land here first.
+The `main` branch is our development branch. All new features land here first.
 
-To try new and experimental features, pull `master` and play with it. Note that `master` may not be stable because new features may introduce bugs.
+To try new and experimental features, pull `main` and play with it. Note that `main` may not be stable because new features may introduce bugs.
 
 Before the release of the next stable version, feature PRs will be frozen. A [release manager](./dev-internal/release#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
 


### PR DESCRIPTION
As branch master has been renamed to main, update branch name in branch_management.md
![image](https://user-images.githubusercontent.com/19908547/123030222-08aeb080-d415-11eb-91de-cf702c5bfc56.png)
