### PR TITLE
Netlify config: drop unnecessary x-robots-tag

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,14 +10,3 @@ command = "npm run build:preview"
 
 [context.branch-deploy]
 command = "npm run build:preview"
-
-# Set headers for docsy conversion development to prevent search engines from
-# indexing the WIP site.
-#
-# Based on hrishikesh's comment here:
-# https://answers.netlify.com/t/prevent-google-indexing-dev-staging-subdomain/32456/8
-[context.branch-deploy.headers]
-  for = "/*"
-  [context.banch-deploy.headers.values]
-    X-Robots-Tag = "noindex"
-


### PR DESCRIPTION
We no longer need the X-Robots-Tag in the branch deploy headers, since Docsy (or Hugo?) manages that based on the build kind (production or development).

Preview: https://deploy-preview-409--etcd.netlify.app/

If you look at the page source, each page of the preview contains the following:

```html
<meta name=ROBOTS content="NOINDEX, NOFOLLOW">
```