### PR TITLE
Fix invalid header error

### DIFF
--- a/content/en/docs/v3.3/dev-guide/api_grpc_gateway.md
+++ b/content/en/docs/v3.3/dev-guide/api_grpc_gateway.md
@@ -118,7 +118,7 @@ Set the `Authorization` header to the authentication token to fetch a key using 
 
 ```bash
 curl -L http://localhost:2379/v3/kv/put \
-  -H 'Authorization : sssvIpwfnLAcWAQH.9' \
+  -H 'Authorization: sssvIpwfnLAcWAQH.9' \
   -X POST -d '{"key": "Zm9v", "value": "YmFy"}'
 # {"header":{"cluster_id":"14841639068965178418","member_id":"10276657743932975437","revision":"2","raft_term":"2"}}
 ```

--- a/content/en/docs/v3.4/dev-guide/api_grpc_gateway.md
+++ b/content/en/docs/v3.4/dev-guide/api_grpc_gateway.md
@@ -120,7 +120,7 @@ Set the `Authorization` header to the authentication token to fetch a key using 
 
 ```bash
 curl -L http://localhost:2379/v3/kv/put \
-  -H 'Authorization : sssvIpwfnLAcWAQH.9' \
+  -H 'Authorization: sssvIpwfnLAcWAQH.9' \
   -X POST -d '{"key": "Zm9v", "value": "YmFy"}'
 # {"header":{"cluster_id":"14841639068965178418","member_id":"10276657743932975437","revision":"2","raft_term":"2"}}
 ```


### PR DESCRIPTION
Fix the curl command for put with authorization.

Error:
curl -L http://localhost:2379/v3/kv/put -H 'Authorization : RBDcjcpEkwbrDIIi.41' -X POST -d '{"key": "Zm9v", "value": "YmFy"}'
400 Bad Request: invalid header name

After fix:
curl -L http://localhost:2379/v3/kv/put -H 'Authorization: RBDcjcpEkwbrDIIi.41' -X POST -d '{"key": "Zm9v", "value": "YmFy"}'
{"header":{"cluster_id":"12841639068965178490","member_id":"10376657743932975472","revision":"2","raft_term":"2"}}