### PR TITLE
Use head-css.html docsy override with tweak for IsProduction

### DIFF
--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -1,0 +1,11 @@
+{{/* etcd-docsy file override */ -}}
+{{ $scssMain := "scss/main.scss"}}
+{{ if not hugo.IsProduction }}
+{{/* Note the missing postCSS. This makes it snappier to develop in Chrome, but makes it look sub-optimal in other browsers. */}}
+{{ $css := resources.Get $scssMain | toCSS (dict "enableSourceMap" true) }}
+<link href="{{ $css.RelPermalink }}" rel="stylesheet">
+{{ else }}
+{{ $css := resources.Get $scssMain | toCSS (dict "enableSourceMap" false) | postCSS | minify | fingerprint }}
+<link rel="preload" href="{{ $css.RelPermalink }}" as="style">
+<link href="{{ $css.RelPermalink }}" rel="stylesheet" integrity="{{ $css.Data.integrity }}">
+{{ end }}


### PR DESCRIPTION
- This introduces a proper docsy override of the partial formerly named `css.html` (that was deleted via #388).
- Generates a production version based on `hugo.IsProduction` rather than `.Site.IsServer`. This makes it easier to create local development builds.
- No change in the generated site files.

Signed-off-by: Patrice Chalin <pchalin@gmail.com>