### PR TITLE
Upgrade Hugo to 0.87.0, and netlify-cli to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.3.1",
-    "hugo-extended": "^0.83.1",
-    "netlify-cli": "^3.39.4",
+    "hugo-extended": "^0.87.0",
+    "netlify-cli": "^6.3.5",
     "postcss": "^8.3.5",
     "postcss-cli": "^8.3.1"
   }


### PR DESCRIPTION
The following two features impact the page generation:

- Hugo v0.86.0: the render-link hook is now applied to _all_ links, not just those written with the markdown syntax `[...](...)`. For details, see [markup/goldmark: Support auto links in render hook
](https://github.com/gohugoio/hugo/commit/ee3d2bb1d3974584f47cde7c973fbd1ae1f512b6)
- Hugo v0.87.0: accessibility improvement, [markup: Add tabindex="0" to default \<pre> wrapper](https://github.com/gohugoio/hugo/pull/8568)

Modulo the changes induced by these two features, whitespace and date/time stamps, the generate site files contain only one diff:

```diff
--- a/blog/index.html
+++ b/blog/index.html
@@ -59,7 +59,7 @@
 				
 				
 				
-				<a class="nav-link active" href="/blog/" ><span class="active">Blog</span></a>
+				<a class="nav-link" href="/blog/" ><span>Blog</span></a>
 			</li>
 			
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
```

Which is a bug, but this allowed me to note that we already had this bug, it's just now being more consistently applied -- i.e., the **Blog** top-nav entry isn't being shown as active when it should. For details, see #443.
