### PR TITLE
CI: fix command-not-found error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,16 @@ LATESTv=v3.5
 HTMLTEST_DIR=tmp
 HTMLTEST?=htmltest # Specify as make arg if different
 # Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
-ifeq (, $(shell command -v $(HTMLTEST)))
+ifeq (, $(shell which $(HTMLTEST)))
 GET_LINK_CHECKER_IF_NEEDED=get-link-checker
 override HTMLTEST=$(HTMLTEST_DIR)/bin/htmltest
 endif
+
+check-internal-links: clean-htmltest-dir link-check-prep
+	$(HTMLTEST)
+
+check-all-links: clean-htmltest-dir link-check-prep
+	$(HTMLTEST) --conf .htmltest.external.yml
 
 docker-serve:
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) server $(DRAFT_ARGS)
@@ -31,9 +37,3 @@ link-check-prep: $(GET_LINK_CHECKER_IF_NEEDED)
 		ln -s $(NEXTv) next; \
 		ln -s $(LATESTv) latest; \
 	)
-
-check-internal-links: clean-htmltest-dir link-check-prep
-	$(HTMLTEST)
-
-check-all-links: clean-htmltest-dir link-check-prep
-	$(HTMLTEST) --conf .htmltest.external.yml


### PR DESCRIPTION
Closes #441

No more error:

```nocode
1:21:36 PM: > @ postbuild:preview /opt/build/repo
1:21:36 PM: > npm run check-links
1:21:36 PM: > @ check-links /opt/build/repo
1:21:36 PM: > make check-internal-links
1:21:36 PM: rm -Rf tmp
1:21:36 PM: curl https://htmltest.wjdp.uk | bash -s -- -b tmp/bin
```

/cc @nate-double-u 