### PR TITLE
Remove the outdated gif screenshot and refine the behavior of auth

### DIFF
--- a/content/en/docs/v3.1/demo.md
+++ b/content/en/docs/v3.1/demo.md
@@ -432,25 +432,30 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 
 `auth`,`user`,`role` for authentication:
 
-<img src="https://storage.googleapis.com/etcd/demo/14_etcdctl_auth_2016062301.gif" alt="14_etcdctl_auth_2016062301"/>
-
 ```
 export ETCDCTL_API=3
 ENDPOINTS=localhost:2379
 
 etcdctl --endpoints=${ENDPOINTS} role add root
-etcdctl --endpoints=${ENDPOINTS} role grant-permission root readwrite foo
 etcdctl --endpoints=${ENDPOINTS} role get root
 
 etcdctl --endpoints=${ENDPOINTS} user add root
 etcdctl --endpoints=${ENDPOINTS} user grant-role root root
 etcdctl --endpoints=${ENDPOINTS} user get root
 
+etcdctl --endpoints=${ENDPOINTS} role add role0
+etcdctl --endpoints=${ENDPOINTS} role grant-permission role0 readwrite foo
+etcdctl --endpoints=${ENDPOINTS} user add user0
+etcdctl --endpoints=${ENDPOINTS} user grant-role user0 role0
+
 etcdctl --endpoints=${ENDPOINTS} auth enable
 # now all client requests go through auth
 
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 put foo bar
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 put foo bar
 etcdctl --endpoints=${ENDPOINTS} get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo1
+# permission denied, user name is empty because the request does not issue an authentication request
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo
+# user0 can read the key foo
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo1
+# permission denied, user0 does not have roles which can read foo1
 ```

--- a/content/en/docs/v3.2/demo.md
+++ b/content/en/docs/v3.2/demo.md
@@ -432,25 +432,30 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 
 `auth`,`user`,`role` for authentication:
 
-<img src="https://storage.googleapis.com/etcd/demo/14_etcdctl_auth_2016062301.gif" alt="14_etcdctl_auth_2016062301"/>
-
 ```
 export ETCDCTL_API=3
 ENDPOINTS=localhost:2379
 
 etcdctl --endpoints=${ENDPOINTS} role add root
-etcdctl --endpoints=${ENDPOINTS} role grant-permission root readwrite foo
 etcdctl --endpoints=${ENDPOINTS} role get root
 
 etcdctl --endpoints=${ENDPOINTS} user add root
 etcdctl --endpoints=${ENDPOINTS} user grant-role root root
 etcdctl --endpoints=${ENDPOINTS} user get root
 
+etcdctl --endpoints=${ENDPOINTS} role add role0
+etcdctl --endpoints=${ENDPOINTS} role grant-permission role0 readwrite foo
+etcdctl --endpoints=${ENDPOINTS} user add user0
+etcdctl --endpoints=${ENDPOINTS} user grant-role user0 role0
+
 etcdctl --endpoints=${ENDPOINTS} auth enable
 # now all client requests go through auth
 
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 put foo bar
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 put foo bar
 etcdctl --endpoints=${ENDPOINTS} get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo1
+# permission denied, user name is empty because the request does not issue an authentication request
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo
+# user0 can read the key foo
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo1
+# permission denied, user0 does not have roles which can read foo1
 ```

--- a/content/en/docs/v3.3/demo.md
+++ b/content/en/docs/v3.3/demo.md
@@ -432,25 +432,29 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 
 `auth`,`user`,`role` for authentication:
 
-<img src="https://storage.googleapis.com/etcd/demo/14_etcdctl_auth_2016062301.gif" alt="14_etcdctl_auth_2016062301"/>
-
 ```
 export ETCDCTL_API=3
 ENDPOINTS=localhost:2379
 
 etcdctl --endpoints=${ENDPOINTS} role add root
-etcdctl --endpoints=${ENDPOINTS} role grant-permission root readwrite foo
 etcdctl --endpoints=${ENDPOINTS} role get root
 
 etcdctl --endpoints=${ENDPOINTS} user add root
 etcdctl --endpoints=${ENDPOINTS} user grant-role root root
 etcdctl --endpoints=${ENDPOINTS} user get root
 
+etcdctl --endpoints=${ENDPOINTS} role add role0
+etcdctl --endpoints=${ENDPOINTS} role grant-permission role0 readwrite foo
+etcdctl --endpoints=${ENDPOINTS} user add user0
+etcdctl --endpoints=${ENDPOINTS} user grant-role user0 role0
+
 etcdctl --endpoints=${ENDPOINTS} auth enable
 # now all client requests go through auth
 
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 put foo bar
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 put foo bar
 etcdctl --endpoints=${ENDPOINTS} get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo1
+# permission denied, user name is empty because the request does not issue an authentication request
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo
+# user0 can read the key foo
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo1
 ```

--- a/content/en/docs/v3.4/demo.md
+++ b/content/en/docs/v3.4/demo.md
@@ -437,25 +437,29 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 
 `auth`,`user`,`role` for authentication:
 
-![14_etcdctl_auth_2016062301](https://storage.googleapis.com/etcd/demo/14_etcdctl_auth_2016062301.gif)
-
 ```shell
 export ETCDCTL_API=3
 ENDPOINTS=localhost:2379
 
 etcdctl --endpoints=${ENDPOINTS} role add root
-etcdctl --endpoints=${ENDPOINTS} role grant-permission root readwrite foo
 etcdctl --endpoints=${ENDPOINTS} role get root
 
 etcdctl --endpoints=${ENDPOINTS} user add root
 etcdctl --endpoints=${ENDPOINTS} user grant-role root root
 etcdctl --endpoints=${ENDPOINTS} user get root
 
+etcdctl --endpoints=${ENDPOINTS} role add role0
+etcdctl --endpoints=${ENDPOINTS} role grant-permission role0 readwrite foo
+etcdctl --endpoints=${ENDPOINTS} user add user0
+etcdctl --endpoints=${ENDPOINTS} user grant-role user0 role0
+
 etcdctl --endpoints=${ENDPOINTS} auth enable
 # now all client requests go through auth
 
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 put foo bar
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 put foo bar
 etcdctl --endpoints=${ENDPOINTS} get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo1
+# permission denied, user name is empty because the request does not issue an authentication request
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo
+# user0 can read the key foo
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo1
 ```

--- a/content/en/docs/v3.5/demo.md
+++ b/content/en/docs/v3.5/demo.md
@@ -437,25 +437,29 @@ etcd --data-dir=data.etcd --name ${THIS_NAME} \
 
 `auth`,`user`,`role` for authentication:
 
-![14_etcdctl_auth_2016062301](https://storage.googleapis.com/etcd/demo/14_etcdctl_auth_2016062301.gif)
-
 ```shell
 export ETCDCTL_API=3
 ENDPOINTS=localhost:2379
 
 etcdctl --endpoints=${ENDPOINTS} role add root
-etcdctl --endpoints=${ENDPOINTS} role grant-permission root readwrite foo
 etcdctl --endpoints=${ENDPOINTS} role get root
 
 etcdctl --endpoints=${ENDPOINTS} user add root
 etcdctl --endpoints=${ENDPOINTS} user grant-role root root
 etcdctl --endpoints=${ENDPOINTS} user get root
 
+etcdctl --endpoints=${ENDPOINTS} role add role0
+etcdctl --endpoints=${ENDPOINTS} role grant-permission role0 readwrite foo
+etcdctl --endpoints=${ENDPOINTS} user add user0
+etcdctl --endpoints=${ENDPOINTS} user grant-role user0 role0
+
 etcdctl --endpoints=${ENDPOINTS} auth enable
 # now all client requests go through auth
 
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 put foo bar
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 put foo bar
 etcdctl --endpoints=${ENDPOINTS} get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo
-etcdctl --endpoints=${ENDPOINTS} --user=root:123 get foo1
+# permission denied, user name is empty because the request does not issue an authentication request
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo
+# user0 can read the key foo
+etcdctl --endpoints=${ENDPOINTS} --user=user0:123 get foo1
 ```


### PR DESCRIPTION
The outdated documentation related to auth was reported in https://github.com/etcd-io/etcd/issues/12966
This PR fixes the issue. It removes the screenshot gif and enhance the command line description.

The behavior of the root role was fixed in https://github.com/etcd-io/etcd/issues/6355 , the root can access to every key so it doesn't cause permission errors described in the current doc.
