### PR TITLE
NPM script updates: ensure that check-links first builds, add submodule:update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "scripts": {
+    "_check-links": "make check-internal-links",
     "build-and-serve": "npm run build && npm run serve",
     "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "hugo --cleanDestinationDir -e dev -DFE",
-    "check-links": "make check-internal-links",
-    "get-submodules": "git submodule update --init --recursive --depth 1",
-    "postbuild:preview": "npm run check-links",
-    "preinstall": "npm run get-submodules",
-    "serve": "netlify dev -c \"hugo serve --minify -DFE -w\""
+    "check-links": "npm run _check-links",
+    "postbuild:preview": "npm run _check-links",
+    "precheck-links": "npm run build",
+    "preinstall": "npm run submodule:get",
+    "serve": "netlify dev -c \"hugo serve --minify -DFE -w\"",
+    "submodule:get": "git submodule update --init --recursive --depth 1",
+    "submodule:update": "git submodule update --remote --recursive --depth 1"
   },
   "devDependencies": {
     "autoprefixer": "^10.3.1",


### PR DESCRIPTION
This PR sets `build` as a pre-step to `check-links` because, after making site changes, it can be easy to forget to build first. If you just want to check links, run `_check-links`.

/cc @kapunahelewong 