### PR TITLE
Streamline link-checking build config and commands

### DIFF
--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -1,4 +1,0 @@
-DirectoryPath: tmp/public
-IgnoreDirectoryMissingTrailingSlash: true
-IgnoreAltMissing: true
-IgnoreURLs: [example.com]

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,4 +1,8 @@
-DirectoryPath: tmp/public
+DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
-CheckExternal: false
+IgnoreURLs:
+  - "^http://play.etcd.io.*"
+IgnoreInternalURLs:
+  - /docs/latest/
+  - /docs/latest/install/

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,37 @@
 DOCKER_IMG = klakegg/hugo:ext-alpine
 DRAFT_ARGS = --buildDrafts --buildFuture  --buildExpired
 
-# Keep these consistent with the values in config.yaml and layouts/index.redirects:
-NEXTv=v3.5
-LATESTv=v3.5
-
-HTMLTEST_DIR=tmp
 HTMLTEST?=htmltest # Specify as make arg if different
+HTMLTEST_ARGS?=--skip-external
+HTMLTEST_DIR=tmp
+
 # Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
 ifeq (, $(shell which $(HTMLTEST)))
-GET_LINK_CHECKER_IF_NEEDED=get-link-checker
 override HTMLTEST=$(HTMLTEST_DIR)/bin/htmltest
+ifeq (, $(shell which $(HTMLTEST)))
+GET_LINK_CHECKER_IF_NEEDED=get-link-checker
+endif
 endif
 
-check-internal-links: clean-htmltest-dir link-check-prep
-	$(HTMLTEST)
-
-check-all-links: clean-htmltest-dir link-check-prep
-	$(HTMLTEST) --conf .htmltest.external.yml
+check-links: $(GET_LINK_CHECKER_IF_NEEDED)
+	$(HTMLTEST) $(HTMLTEST_ARGS)
 
 docker-serve:
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) server $(DRAFT_ARGS)
 
-clean-htmltest-dir:
-	rm -Rf $(HTMLTEST_DIR)
-
+# Until htmltext >0.14.x is released, get and build our own from source:
 get-link-checker:
-	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin
-
-link-check-prep: $(GET_LINK_CHECKER_IF_NEEDED)
-	mkdir -p $(HTMLTEST_DIR)
-	rm -Rf $(HTMLTEST_DIR)/public
-	cp -R public/ $(HTMLTEST_DIR)/public && \
+	rm -Rf $(HTMLTEST_DIR)
+	mkdir -p $(HTMLTEST_DIR)/bin && \
+	cd $(HTMLTEST_DIR) && \
+	git clone --depth=1 https://github.com/wjdp/htmltest.git && \
 	( \
-		cd $(HTMLTEST_DIR)/public/docs; \
-		ln -s $(NEXTv) next; \
-		ln -s $(LATESTv) latest; \
+		cd htmltest && \
+		./build.sh && \
+		cp bin/htmltest ../bin \
 	)
+
+# Once htmltext >0.14.x is released, replace the get-and-build code above with this:
+# get-link-checker:
+# 	rm -Rf $(HTMLTEST_DIR)/bin
+# 	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
 publish = "public"
 command = "npm run build:production"
 
+[build.environment]
+GO_VERSION = "1.16" # Temporary, while we need to build htmltext >v0.14
+
 [context.deploy-preview]
 command = "npm run build:preview"
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "scripts": {
-    "_check-links": "make check-internal-links",
+    "_check-links": "make check-links",
     "build-and-serve": "npm run build && npm run serve",
     "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "hugo --cleanDestinationDir -e dev -DFE",
+    "check-links:all": "HTMLTEST_ARGS= npm run _check-links",
     "check-links": "npm run _check-links",
     "postbuild:preview": "npm run _check-links",
+    "precheck-links:all": "npm run build",
     "precheck-links": "npm run build",
     "preinstall": "npm run submodule:get",
     "serve": "netlify dev -c \"hugo serve --minify -DFE -w\"",


### PR DESCRIPTION
- Use `--skip-external` flag instead of having two `htmltest` config files.
- As necessary, build `htmltest` from source so that we have the latest features!
  - Once build,`htmltest` will be reused (rather than refetched & rebuilt).
- Ignore `/docs/latest` so that we no longer need to setup symlinks

---

If you've previously run the link checker scripts, you'll first need to delete the `HTMLTEST` directory before running the link checking scripts again. To do this run this command:

```sh
# From your etcd.io website repo directory
$ rm -Rf tmp
```