### PR TITLE
Only fingerprint offline search data in production mode

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,0 +1,30 @@
+{{/* etcd-docsy file override */ -}}
+{{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
+<input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+{{ else if .Site.Params.offlineSearch }}
+{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . }}
+{{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */}}
+{{ $offlineSearchIndexFingerprint := $offlineSearchIndex | resources.Fingerprint "md5" }}
+{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+{{ if hugo.IsProduction -}}
+{{ $offlineSearchLink = $offlineSearchIndexFingerprint.RelPermalink -}}
+{{ end -}}
+
+<input
+  type="search"
+  class="form-control td-search-input"
+  placeholder="&#xf002; {{ T "ui_search" }}"
+  aria-label="{{ T "ui_search" }}"
+  autocomplete="off"
+  {{/*
+    The data attribute name of the json file URL must end with `src` since
+    Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
+    If the absurlreplacer is not applied, the URL will start with `/`.
+    It causes the json file loading error when when relativeURLs is enabled.
+    https://github.com/google/docsy/issues/181
+  */}}
+  data-offline-search-index-json-src="{{ $offlineSearchLink }}"
+  data-offline-search-base-href="/"
+  data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
+>
+{{ end }}


### PR DESCRIPTION
Otherwise, it makes it difficult to diff generated site files in development mode.

Until we properly setup our use of the CNCF docsy, here's the diff relative to the docsy-base file:

```diff
> diff -c {themes/docsy/,}layouts/partials/search-input.html
*** themes/docsy/layouts/partials/search-input.html     2021-09-15 16:27:50.000000000 -0400
--- layouts/partials/search-input.html  2021-09-15 16:27:30.000000000 -0400
***************
*** 1,9 ****
--- 1,15 ----
+ {{/* etcd-docsy file override */ -}}
  {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
  <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
  {{ else if .Site.Params.offlineSearch }}
  {{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . }}
  {{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */}}
  {{ $offlineSearchIndexFingerprint := $offlineSearchIndex | resources.Fingerprint "md5" }}
+ {{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+ {{ if hugo.IsProduction -}}
+ {{ $offlineSearchLink = $offlineSearchIndexFingerprint.RelPermalink -}}
+ {{ end -}}
+ 
  <input
    type="search"
    class="form-control td-search-input"
***************
*** 17,23 ****
      It causes the json file loading error when when relativeURLs is enabled.
      https://github.com/google/docsy/issues/181
    */}}
!   data-offline-search-index-json-src="{{ $offlineSearchIndexFingerprint.RelPermalink }}"
    data-offline-search-base-href="/"
    data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
  >
--- 23,29 ----
      It causes the json file loading error when when relativeURLs is enabled.
      https://github.com/google/docsy/issues/181
    */}}
!   data-offline-search-index-json-src="{{ $offlineSearchLink }}"
    data-offline-search-base-href="/"
    data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
  >
```

There is no change in the generated site files except for the fingerprint as part of the `` filename:

```console
$ (cd public && git diff -b -w -I data-offline-search -- . ':(exclude)*.xml' ':(exclude)*.map' ':(exclude)*.json')
$
```
