### PR TITLE
Quickstart v3.5: Modified the Quickstart page of v3.5 to contain basic setup for authentication

### DIFF
--- a/content/en/docs/v3.5/quickstart.md
+++ b/content/en/docs/v3.5/quickstart.md
@@ -4,81 +4,61 @@ weight: 900
 description: Get etcd up and running in less than 5 minutes!
 ---
 
-Follow the instructions below to locally install, run, and test a simple
-single-member cluster of etcd.
+Follow these instructions to locally install, run, test and set up user authentication in a single-member cluster of etcd:
 
-## Install etcd
+ 1. Install etcd from pre-built binaries or from source. For details, see
+    [Install][].
 
-To help with the commands that follow, set these environment variables:
+    {{% alert color="warning" %}}**Important**: Ensure that you perform the last
+    step of the installation instructions to verify that `etcd` is in your path.
+    {{% /alert %}}
 
-```
-ETCD_VER={{< param git_version_tag >}}
-ETCD_BIN=/tmp/test-etcd
+ 2. Launch `etcd`:
 
-GOOGLE_URL=https://storage.googleapis.com/etcd
-GITHUB_URL=https://github.com/etcd-io/etcd/releases/download
-```
+    ```
+    $ etcd
+    {"level":"info","ts":"2021-09-17T09:19:32.783-0400","caller":"etcdmain/etcd.go:72","msg":"Running: ","args":["etcd"]}
+    ⋮
+    ```
 
-Download and install etcd from pre-built binaries:
+    {{% alert color="info" %}}**Note**: The output produced by `etcd` are
+    [logs](../op-guide/configuration/#logging-flags) &mdash; info-level logs can
+    be ignored. {{% /alert %}}
 
-On Linux
+ 3. From **another terminal**, use `etcdctl` to set a key:
 
-```
-DOWNLOAD_URL=${GITHUB_URL}
+    ```
+    $ etcdctl put greeting "Hello, etcd"
+    OK
+    ```
 
-rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
-rm -rf $ETCD_BIN
-mkdir -p $ETCD_BIN
+ 4. From the same terminal, retrieve the key:
 
-curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+    ```
+    $ etcdctl get greeting
+    greeting
+    Hello, etcd
+    ```
+ 5. To enable the root user to authenticate new users and set up their respective roles, the root user must be created and also authenctication must be enabled by using the following commands:
 
-tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C $ETCD_BIN --strip-components=1
-```
-
-On macOS
-
-```
-DOWNLOAD_URL=${GOOGLE_URL}
-
-rm -f /tmp/etcd-${ETCD_VER}-darwin-amd64.zip
-rm -rf /tmp/etcd-${ETCD_VER}-darwin-amd64
-rm -rf $ETCD_BIN
-mkdir -p $ETCD_BIN
-
-curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-darwin-amd64.zip -o /tmp/etcd-${ETCD_VER}-darwin-amd64.zip
-
-unzip /tmp/etcd-${ETCD_VER}-darwin-amd64.zip -d /tmp
-ln -s /tmp/etcd-${ETCD_VER}-darwin-amd64/* $ETCD_BIN
-```
-
-{{% alert title="Note" color="info" %}}
-To work with the latest version, learn how to [build from the main branch](/docs/{{< param version >}}/install/#build-from-source).
-{{% /alert %}}
-
-## Launch etcd
-
-```
-$ $ETCD_BIN/etcd
-{"level":"warn","ts":"2021-05-12T11:03:01.247-0700","caller":"etcdmain/etcd.go:119","msg":"'data-dir' was empty; using default","data-dir":"default.etcd"}
-⋮
-```
-
-## Set and get a key
-
-From another terminal, use etcdctl to set a key:
-
-```
-$ $ETCD_BIN/etcdctl put greeting "Hello, etcd"
-OK
-```
-
-Now that a key has been set, retrieve it:
-
-```
-$ $ETCD_BIN/etcdctl get greeting
-greeting
-Hello, etcd
-```
+    ```
+    $ etcdctl user add root
+    $ etcdctl auth enable
+    ```
+ 6. To add a new user:
+    ```
+    $ etcdctl user add myusername
+    ```
+ 7. To create a new role:
+    ```
+    $ etcdctl role add myrolename
+    ```
+ 8. To assign or revoke a role from a user:
+    ```
+    $ etcdctl user grant-role myusername keyname
+    $ etcdctl user revoke-role myusername keyname
+    ```
+    For more details on authentication and role-based access control, see [Role-based Access Control][].
 
 ## What's next?
 
@@ -97,4 +77,5 @@ Learn about more ways to configure and use etcd from the following pages:
 [integrations]: /docs/{{< param version >}}/integrations
 [security]: /docs/{{< param version >}}/op-guide/security
 [tuning]: /docs/{{< param version >}}/tuning
-
+[Install]: ../install/
+[Role-based Access Control]: ../op-guide/authentication/


### PR DESCRIPTION
According to a discussion earlier with @nate-double-u and @spzala  (Refer: https://github.com/etcd-io/website/pull/476#issuecomment-921053192), I have modified the quickstart page of v3.5 to contain some basic information on how to set up authentication and assign roles to new users.
Deploy preview: https://deploy-preview-490--etcd.netlify.app/