### PR TITLE
Improved sidebar indentation

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -158,6 +158,11 @@
   padding-top: 4.75rem;
 }
 
+.td-sidebar-nav__section {
+  .ul-1 ul { padding-left: 1rem; }
+  .ul-2 { padding-left: 0 !important; }
+}
+
 // Custom in-page toc. Apply this class as a modifier on top of the Docsy-provided .td-toc
 .td-toc--inline {
   padding-top: 0;


### PR DESCRIPTION
- Followup to #494
- Removes sidebar indentation from version top-level pages, giving us more sidebar real estate for nested pages. (We don't lose anything w/o that level of indentation because one is never looking at the pages across two versions at the same time, and it is clear which version section we're in.)
- Use the same sidebar indentation for desktop & mobile (as opposed to the default mobile all-flat sidebar)

## Screenshots

### Desktop

Before:

> ![image](https://user-images.githubusercontent.com/4140793/134152044-79cf4f22-a3f9-4089-9d48-aba648b85aab.png)

After:

> ![image](https://user-images.githubusercontent.com/4140793/134152145-90c47178-ce76-4321-b606-f7a548c50eb3.png)

### Mobile

Before:

> <img src="https://user-images.githubusercontent.com/4140793/134152561-db0257f0-f330-4da7-a62f-5e1186cf7907.png" width=300>

After:

> <img src="https://user-images.githubusercontent.com/4140793/134152389-7128ecdf-7971-4adc-8ccc-1d581a633b69.png" width=300>

