### PR TITLE
Disable translucent top nav

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,20 +96,12 @@ params:
 
   # User interface configuration
   ui:
-    # Enable to show the side bar menu in its compact state.
     sidebar_menu_compact: true
-
-    #  Set to true to disable breadcrumb navigation.
     breadcrumb_disable: false
-
-    #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
     sidebar_search_disable: false
-
-    #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
     navbar_logo: true
-
-    # Set to true to disable the About link in the site footer
     footer_about_disable: true
+    navbar_translucent_over_cover_disable: true
 
     # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
     # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
Closes #501

Note: There is a slight color difference (by design) between the top-nav's use of the primary color and the underlying `block/cover`s background use of the primary color.