### PR TITLE
Added 'How to delete keys' page under 'Tutorials' section and updated demo page

### DIFF
--- a/content/en/docs/v3.5/demo.md
+++ b/content/en/docs/v3.5/demo.md
@@ -140,21 +140,6 @@ etcdctl --endpoints=$ENDPOINTS put web3 value3
 etcdctl --endpoints=$ENDPOINTS get web --prefix
 ```
 
-
-## Delete
-
-![04_etcdctl_delete_2016050601](https://storage.googleapis.com/etcd/demo/04_etcdctl_delete_2016050601.gif)
-
-```shell
-etcdctl --endpoints=$ENDPOINTS put key myvalue
-etcdctl --endpoints=$ENDPOINTS del key
-
-etcdctl --endpoints=$ENDPOINTS put k1 value1
-etcdctl --endpoints=$ENDPOINTS put k2 value2
-etcdctl --endpoints=$ENDPOINTS del k --prefix
-```
-
-
 ## Transactional write
 
 `txn` to wrap multiple requests into one transaction:

--- a/content/en/docs/v3.5/tutorials/_index.md
+++ b/content/en/docs/v3.5/tutorials/_index.md
@@ -1,0 +1,3 @@
+---
+title: Tutorials
+---

--- a/content/en/docs/v3.5/tutorials/how-to-delete-keys.md
+++ b/content/en/docs/v3.5/tutorials/how-to-delete-keys.md
@@ -1,0 +1,15 @@
+---
+title: How to delete keys
+description: Describes a way to delete etcd keys
+---
+
+![04_etcdctl_delete_2016050601](https://storage.googleapis.com/etcd/demo/04_etcdctl_delete_2016050601.gif)
+
+```shell
+etcdctl --endpoints=$ENDPOINTS put key myvalue
+etcdctl --endpoints=$ENDPOINTS del key
+
+etcdctl --endpoints=$ENDPOINTS put k1 value1
+etcdctl --endpoints=$ENDPOINTS put k2 value2
+etcdctl --endpoints=$ENDPOINTS del k --prefix
+```


### PR DESCRIPTION
Moved the section on "how to delete etcd keys" from the Demo page to a new section "Tutorials" and removed the same from the demo page.
Contributes to #402 
Deploy preview: https://deploy-preview-515--etcd.netlify.app/docs/v3.5/tutorials/how-to-delete-keys/