### PR TITLE
Document the user experience change since v3.5.0 on the `/health` endpoint when authentication is enabled.

### DIFF
--- a/content/en/docs/v3.5/op-guide/monitoring.md
+++ b/content/en/docs/v3.5/op-guide/monitoring.md
@@ -67,6 +67,8 @@ etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"} 406464
 
 Since v3.3.0, in addition to responding to the `/metrics` endpoint, any locations specified by `--listen-metrics-urls` will also respond to the `/health` endpoint. This can be useful if the standard endpoint is configured with mutual (client) TLS authentication, but a load balancer or monitoring service still needs access to the health check.
 
+Since v3.5.0, the request to `/health` endpoint will also be authenticated if the authentication is enabled. In this case, users are supposed to submit HTTPS requests on the `/health` endpoint, so that etcd can get the auto info from the certificate.
+
 ## Prometheus
 
 Running a [Prometheus][prometheus] monitoring service is the easiest way to ingest and record etcd's metrics.


### PR DESCRIPTION
fix https://github.com/etcd-io/etcd/issues/13415 . 

Previously in etcd 3.4, the requests on `/health` are not authenticated even the authentication is enabled. But since etcd v3.5.0, it will be authenticated if the authentication is enabled. So we need to document the user experience change in 3.5.0. 