### PR TITLE
Upgrade hugo-extended

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.3.1",
-    "hugo-extended": "^0.87.0",
+    "hugo-extended": "0.88.1-patch1",
     "netlify-cli": "^6.3.5",
     "postcss": "^8.3.5",
     "postcss-cli": "^8.3.1"


### PR DESCRIPTION
This is to avoid issues like https://github.com/open-telemetry/opentelemetry.io/issues/823 due to https://github.com/jakejarvis/hugo-extended/issues/77.

No essential differences in the generated site files other than extra `tabindex="0"` attributes on `pre` elements. After removing all such tabindexes, no differences are reported (modulo Hugo version):

```console
$ cd public
$ find . -type f -name "*.html" -exec perl -pi -e 's|pre tabindex="0"|pre|' {} \; # normalize before and after
$ git diff -b -w --ignore-blank-lines -I "Hugo 0.8" -- . ':(exclude)*.xml'
$
```

/cc @nate-double-u 