### PR TITLE
Organizing tutorials section

### DIFF
--- a/content/en/docs/v3.5/tutorials/_index.md
+++ b/content/en/docs/v3.5/tutorials/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Tutorials
+weight: 1110
 ---

--- a/content/en/docs/v3.5/tutorials/how-to-access-etcd.md
+++ b/content/en/docs/v3.5/tutorials/how-to-access-etcd.md
@@ -1,6 +1,7 @@
 ---
 title: How to access etcd
 description: Guide to access an etcd cluster
+weight: 200
 ---
 
 

--- a/content/en/docs/v3.5/tutorials/how-to-check-cluster-status.md
+++ b/content/en/docs/v3.5/tutorials/how-to-check-cluster-status.md
@@ -1,6 +1,7 @@
 ---
 title: How to check Cluster status
 description: Guide to checking etcd cluster status
+weight: 1000
 ---
 
 

--- a/content/en/docs/v3.5/tutorials/how-to-conduct-elections.md
+++ b/content/en/docs/v3.5/tutorials/how-to-conduct-elections.md
@@ -1,6 +1,7 @@
 ---
 title: How to conduct leader election in etcd cluster
 description: Guide to conducting leader election in an etcd cluster
+weight: 900
 ---
 
 `elect` for leader election:

--- a/content/en/docs/v3.5/tutorials/how-to-create-lease.md
+++ b/content/en/docs/v3.5/tutorials/how-to-create-lease.md
@@ -1,6 +1,7 @@
 ---
 title: How to create lease
 description: Guide to creating a lease in etcd
+weight: 700
 ----
 
 `lease` to write with TTL:

--- a/content/en/docs/v3.5/tutorials/how-to-create-locks.md
+++ b/content/en/docs/v3.5/tutorials/how-to-create-locks.md
@@ -1,6 +1,7 @@
 ---
 title: How to create locks
 description: Guide to creating distributed locks in etcd
+weight: 800
 ---
 
 `lock` for distributed lock:

--- a/content/en/docs/v3.5/tutorials/how-to-deal-with-membership.md
+++ b/content/en/docs/v3.5/tutorials/how-to-deal-with-membership.md
@@ -1,6 +1,7 @@
 ---
 title: How to Add and Remove Members
 description: Guide to dealing with membership in etcd cluster
+weight: 1300
 ---
 
 

--- a/content/en/docs/v3.5/tutorials/how-to-delete-keys.md
+++ b/content/en/docs/v3.5/tutorials/how-to-delete-keys.md
@@ -1,6 +1,7 @@
 ---
 title: How to delete keys
 description: Describes a way to delete etcd keys
+weight: 400
 ---
 
 ![04_etcdctl_delete_2016050601](https://storage.googleapis.com/etcd/demo/04_etcdctl_delete_2016050601.gif)

--- a/content/en/docs/v3.5/tutorials/how-to-migrate.md
+++ b/content/en/docs/v3.5/tutorials/how-to-migrate.md
@@ -1,6 +1,7 @@
 ---
 title: How to migrate from Etcd2 to Etcd3
 description: Migration guide from Etcd2 to Etcd3
+weight: 1200
 ---
 
 

--- a/content/en/docs/v3.5/tutorials/how-to-save-database.md
+++ b/content/en/docs/v3.5/tutorials/how-to-save-database.md
@@ -1,6 +1,7 @@
 ---
 title: How to save the database
 description: Guide to taking a snapshot of the etcd database
+weight: 1100
 ---
 
 

--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -1,6 +1,7 @@
 ---
 title: How to make multiple writes in a transaction
 description: Guide to making transactional writes
+weight: 500
 ---
 
 `txn` to wrap multiple requests into one transaction:

--- a/content/en/docs/v3.5/tutorials/how-to-watch-keys.md
+++ b/content/en/docs/v3.5/tutorials/how-to-watch-keys.md
@@ -1,6 +1,7 @@
 ---
 title: How to watch keys
 description: Guide to watching etcd keys
+weight: 600
 ---
 
 


### PR DESCRIPTION
Organizing the tutorials so that they are in the same order that they were on the demos page.
* Setting weight for the Tutorials page to be just below old Demos page. 
* Setting weight in individual pages to match order in old Demos page.

Deploy previews:
* https://deploy-preview-530--etcd.netlify.app/docs/v3.5/
* https://deploy-preview-530--etcd.netlify.app/docs/v3.5/tutorials/

Contributes to #402 