### PR TITLE
Adding cloud IDE (https://gitpod.io) config file and instructions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+# Commands to start on workspace startup
+tasks:
+  - name: Dev Server
+    init: npm install
+    command: npm run serve
+
+# Ports to expose on workspace startup
+ports:
+  - port: 8888
+    onOpen: open-browser
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,9 @@
 # Commands to start on workspace startup
 tasks:
   - name: Dev Server
-    init: npm install
+    init: |
+      nvm install --lts
+      npm install
     command: npm run serve
 
 # Ports to expose on workspace startup

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # Commands to start on workspace startup
 tasks:
   - name: Dev Server
-    init: npm install
+    init: npm install --lts
     command: npm run serve
 
 # Ports to expose on workspace startup

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # Commands to start on workspace startup
 tasks:
   - name: Dev Server
-    init: npm install --lts
+    init: npm install
     command: npm run serve
 
 # Ports to expose on workspace startup

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 The [etcd.io][] website, built using [Hugo][] and hosted on [Netlify][].
 
-## Build prerequisites
-
-### Cloud build
+## Cloud build
 
 Visit [https://gitpod.io/#https://github.com/etcd-io/website](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
 
-### Local build
+## Local build
 
 To build and serve the site, you'll need the latest [LTS release][] of **Node**.
 Like Netlify, we use **[nvm][]**, the Node Version Manager, to install and
@@ -18,7 +16,7 @@ manage Node versions:
 $ nvm install --lts
 ```
 
-#### Setup
+### Setup
 
  1. Clone this repo.
  2. From a terminal window, change to the cloned repo directory.
@@ -27,7 +25,7 @@ $ nvm install --lts
     $ npm install
     ```
 
-#### Build or serve the site
+### Build or serve the site
 
 To locally serve the site at [localhost:8888][], run the following command:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ The [etcd.io][] website, built using [Hugo][] and hosted on [Netlify][].
 
 ## Build prerequisites
 
+### Cloud build
+
+Visit [https://gitpod.io/#https://github.com/etcd-io/website](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
+
+### Local build
+
 To build and serve the site, you'll need the latest [LTS release][] of **Node**.
 Like Netlify, we use **[nvm][]**, the Node Version Manager, to install and
 manage Node versions:
@@ -12,16 +18,16 @@ manage Node versions:
 $ nvm install --lts
 ```
 
-## Setup
+#### Setup
 
  1. Clone this repo.
  2. From a terminal window, change to the cloned repo directory.
  3. Get NPM packages and git submodules, including the the [Docsy][] theme:
     ```console
-    $ npm install 
+    $ npm install
     ```
 
-## Build or serve the site
+#### Build or serve the site
 
 To locally serve the site at [localhost:8888][], run the following command:
 


### PR DESCRIPTION
I've been working with gitpod.io cloud development environments, and have found it very useful, so I thought I'd make it a  part of this repo.

This change adds a configuration file and instructions for gitpod. When you visit https://gitpod.io/#https://github.com/etcd-io/website, a Gitpod.io IDE is launched that allows you to build, preview and make changes to this repo.

_Note_, visiting the link provided doesn't launch the preview automatically yet as it grabs the `main` branch (it does bring up the IDE, and you can run the preview manually). You can see how it would work by looking at the [Notary Project's](https://github.com/notaryproject/notaryproject.dev) setup: https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev