### PR TITLE
updated the Link Text with a relevant word

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [etcd.io][] website, built using [Hugo][] and hosted on [Netlify][].
 
 ## Cloud build
 
-Visit [https://gitpod.io/#https://github.com/etcd-io/website](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
+Visit [here](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
 
 ## Local build
 


### PR DESCRIPTION
It looks nice to enclose the Link Text with a relevant word so that it helps others as well what the link actually does. I changed the Link Text from a URL to the word here so that it represents by clicking the link from there you can launch ...

```diff
+ Visit [here](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
- Visit [https://gitpod.io/#https://github.com/etcd-io/website](https://gitpod.io/#https://github.com/etcd-io/website) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
