### PR TITLE
Upgrade NPM packages, Hugo to 0.89.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 package-lock.json
 
 # Hugo-generated assets
+.hugo_build.lock
 /public
 resources/
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "submodule:update": "git submodule update --remote --recursive --depth 1"
   },
   "devDependencies": {
-    "autoprefixer": "^10.3.1",
-    "hugo-extended": "0.88.1-patch1",
-    "netlify-cli": "^6.3.5",
-    "postcss": "^8.3.5",
-    "postcss-cli": "^8.3.1"
+    "autoprefixer": "^10.4.0",
+    "hugo-extended": "^0.89.4",
+    "netlify-cli": "^7.0.0",
+    "postcss": "^8.3.11",
+    "postcss-cli": "^9.0.2"
   }
 }


### PR DESCRIPTION
No difference in generated site files, except for code `console` code blacks that now have syntax highlighting! \o/

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.8" -- . ':(exclude)*.xml') | grep -e ^diff
diff --git a/docs/v3.4/quickstart/index.html b/docs/v3.4/quickstart/index.html
diff --git a/docs/v3.5/quickstart/index.html b/docs/v3.5/quickstart/index.html
```