### PR TITLE
Ensure Blog top-nav entry is marked as active for blog pages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -169,7 +169,7 @@ menu:
       url: /docs/latest/
       weight: -10
     - name: Blog
-      url: /blog/
+      pageref: /blog/
     - name: Install
       url: /docs/latest/install/
     - name: Play


### PR DESCRIPTION
Contributes to #538, fixing it for blog pages. The other pages are trickier because they are not real links. I'll have to think about those cases a bit more.

Preview: https://deploy-preview-542--etcd.netlify.app/blog

### Screenshot

![image](https://user-images.githubusercontent.com/4140793/142453055-7ed2a408-1fb9-4ed8-91c5-770edc0235ee.png)
