### PR TITLE
Version menu: show icon when page is missing

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -213,7 +213,7 @@
 // add icon to signify that a link is external
 // from https://fontawesome.com/v5.15/icons/external-link-alt?style=solid
 
-.td-content a[href^="http://"]:after, 
+.td-content a[href^="http://"]:after,
 .td-content a[href^="https://"]:after {
   @extend .fas;
   font-size: 50%;
@@ -228,54 +228,27 @@
 }
 
 // ************************************
-
-// Styles for icon in version menu
-
+// Version menu
 // ************************************
 
-// style options in Versions drop down on the upper right of the docs so that it's clear if a doc exists for a particular version as not all docs exist in all versions
-
-//  establish fontawesome on dropdown:after
-
-a.dropdown-item:after {
-
-  font-family: 'Font Awesome\ 5 Free';  
-  position: relative;
-  bottom: 1px;
-  padding: 0 3px;
-  font-size: .7rem;
-
-}
-
-// Document icon is from https://fontawesome.com/v5.15/icons/file-alt?style=solid and signifies a doc exists in a particular version
-
-a.dropdown-item[href*="/docs/"] {
-  
+.cncf-vers-menu--item {
   &:hover {
-    background: #a0d0ff linear-gradient(180deg, #1f6897, #1f6897) repeat-x;
-    color: #fff;
-  }
-  
-  &:after {
-    content: "\f15c";
+    background: $primary;
+    color: white;
   }
 }
 
-// Remove the doc icon from the version numbers in the dropdown that don't have a corresponding doc. 
-// ~= means that the href value ends in the string specified. Maintainers will have to add new versions as they come out if there aren't docs for that version.
-a.dropdown-item[href~="/docs/v2.3/"], 
-a.dropdown-item[href~="/docs/v3.1/"], 
-a.dropdown-item[href~="/docs/v3.2/"], 
-a.dropdown-item[href~="/docs/v3.3/"], 
-a.dropdown-item[href~="/docs/v3.4/"],
-a.dropdown-item[href~="/docs/v3.5/"] {
-
+.cncf-vers-menu--item__not-found {
+  color: $gray-600;
   &:hover {
-    background:#accff3 linear-gradient(180deg, #deeaf7, #e3ecf5) repeat-x;
-    color: #222;
+    background: lighten($primary, 60%);
+    color: $gray-900;
   }
-  
   &:after {
-    content: "";
+    @extend .fas;
+    font-size: .8rem;
+    padding-left: 6px;
+    content: fa-content($fa-var-home);
+    color: lighten($primary, 15%);
   }
 }


### PR DESCRIPTION
- Closes #296
- With this PR we show a "home" icon when the link is to the version homepage (so this is inverting the situation when an icon is being shown, [as you preferred](https://github.com/etcd-io/website/pull/390#issuecomment-867079006) @nate-double-u).

Preview, selected pages:

- https://deploy-preview-544--etcd.netlify.app/docs -- the versions menu is now disabled for this page. There are enough other ways to access the versions from the **Versions** page 😄 
- https://deploy-preview-544--etcd.netlify.app/docs/latest
- https://deploy-preview-544--etcd.netlify.app/docs/v3.5/quickstart
- https://deploy-preview-544--etcd.netlify.app/docs/v3.5/reporting_bugs
- https://deploy-preview-544--etcd.netlify.app/docs/v2.3/runtime-reconf-design/

---

### Screenshots

> ![image](https://user-images.githubusercontent.com/4140793/143302983-4263e75c-e6b0-48fb-b5a6-5acc5e57d35b.png)

> ![image](https://user-images.githubusercontent.com/4140793/143303061-0d2b27f1-9a78-4387-9914-98b9d8c29996.png)

---

#### Active highlights

> ![image](https://user-images.githubusercontent.com/4140793/143303400-9a8324a1-8b70-4938-afd3-b46ea90bacd0.png)

> ![image](https://user-images.githubusercontent.com/4140793/143303491-04414373-70c7-4657-84ef-ab071ad216a6.png)

---

#### Other sample pages

> ![image](https://user-images.githubusercontent.com/4140793/143303204-fe367262-38fe-47b8-857c-d866bb6bbfe8.png)

> ![image](https://user-images.githubusercontent.com/4140793/143303270-b22d71cd-335b-4897-9544-0f368f395bb4.png)
