### PR TITLE
Add etcd version support policy

### DIFF
--- a/content/en/docs/v3.3/op-guide/versioning.md
+++ b/content/en/docs/v3.3/op-guide/versioning.md
@@ -1,16 +1,27 @@
 ---
 title: Versioning
+weight: 4900
+description: Versioning support by etcd
 ---
 
-## Service versioning
+This document describes the versions supported by the etcd project.
 
-etcd uses [semantic versioning](http://semver.org)
+## Service versioning and supported versions
+
+etcd versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 New minor versions may add additional features to the API.
 
-Get the running etcd cluster version with `etcdctl`:
+The etcd project maintains release branches for the current version and two minor releases, 3.5, 3.4 and 3.3 currently.
+
+Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
+Patch releases are cut from those branches when required.
+
+The project [Maintainers](https://github.com/etcd-io/etcd/blob/main/MAINTAINERS) own this decision.
+
+You can check the running etcd cluster version with `etcdctl`:
 
 ```sh
-ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 endpoint status
+etcdctl --endpoints=127.0.0.1:2379 endpoint status
 ```
 
 ## API versioning

--- a/content/en/docs/v3.4/op-guide/versioning.md
+++ b/content/en/docs/v3.4/op-guide/versioning.md
@@ -1,18 +1,27 @@
 ---
 title: Versioning
 weight: 4900
-description: Semantic versioning with etcd
+description: Versioning support by etcd
 ---
 
-## Service versioning
+This document describes the versions supported by the etcd project.
 
-etcd uses [semantic versioning](http://semver.org)
+## Service versioning and supported versions
+
+etcd versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 New minor versions may add additional features to the API.
 
-Get the running etcd cluster version with `etcdctl`:
+The etcd project maintains release branches for the current version and two minor releases, 3.5, 3.4 and 3.3 currently.
+
+Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
+Patch releases are cut from those branches when required.
+
+The project [Maintainers](https://github.com/etcd-io/etcd/blob/main/MAINTAINERS) own this decision.
+
+You can check the running etcd cluster version with `etcdctl`:
 
 ```sh
-ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 endpoint status
+etcdctl --endpoints=127.0.0.1:2379 endpoint status
 ```
 
 ## API versioning

--- a/content/en/docs/v3.5/op-guide/versioning.md
+++ b/content/en/docs/v3.5/op-guide/versioning.md
@@ -1,18 +1,27 @@
 ---
 title: Versioning
 weight: 4900
-description: Semantic versioning with etcd
+description: Versioning support by etcd
 ---
 
-## Service versioning
+This document describes the versions supported by the etcd project.
 
-etcd uses [semantic versioning](http://semver.org)
+## Service versioning and supported versions
+
+etcd versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 New minor versions may add additional features to the API.
 
-Get the running etcd cluster version with `etcdctl`:
+The etcd project maintains release branches for the current version and two minor releases, 3.5, 3.4 and 3.3 currently.
+
+Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
+Patch releases are cut from those branches when required.
+
+The project [Maintainers](https://github.com/etcd-io/etcd/blob/main/MAINTAINERS) own this decision.
+
+You can check the running etcd cluster version with `etcdctl`:
 
 ```sh
-ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 endpoint status
+etcdctl --endpoints=127.0.0.1:2379 endpoint status
 ```
 
 ## API versioning


### PR DESCRIPTION
The details on the supported versions are missing in the doc.
etcd users has asked this question in the past. The details here
can provide an overview of etcd versioning policy.
Eventually we should make this verisoning page available more
easily but for now adding the details in the current page.