### PR TITLE
fix golang example of with a lease

### DIFF
--- a/content/en/docs/v3.5/dev-guide/grpc_naming.md
+++ b/content/en/docs/v3.5/dev-guide/grpc_naming.md
@@ -72,8 +72,9 @@ ETCDCTL_API=3 etcdctl lease keep-alive $lease
 In the golang:
 
 ```go
+lease, _ := client.Grant(context.TODO(), ttl)
 em := endpoints.NewManager(client, "foo/bar/my-service")
-err := em.AddEndpoint(context.TODO(), "foo/bar/my-service/e1", endpoints.Endpoint{Addr:"1.2.3.4"});
+err := em.AddEndpoint(context.TODO(), "foo/bar/my-service/e1", endpoints.Endpoint{Addr:"1.2.3.4"}, clientv3.WithLease(lease.ID));
 ```
 
 ### Atomically updating endpoints


### PR DESCRIPTION
fix golang example of registering an endpoint with a lease