### PR TITLE
Canceled grpc is now not considered an error

### DIFF
--- a/content/en/docs/v3.4/op-guide/etcd3_alert.rules.yml
+++ b/content/en/docs/v3.4/op-guide/etcd3_alert.rules.yml
@@ -34,7 +34,7 @@ groups:
       message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
         $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
     expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!~"OK|Canceled"}[5m])) BY (job, instance, grpc_service, grpc_method)
         /
       sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
         > 1
@@ -46,7 +46,7 @@ groups:
       message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
         $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
     expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!~"OK|Canceled"}[5m])) BY (job, instance, grpc_service, grpc_method)
         /
       sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
         > 5


### PR DESCRIPTION
"Canceled" grpc state means client-initiated cancellation of streaming
grpc call, e.g. Watch. This is a legitimate non-error case. Before this
change such codes were considered an error and created false positive
alerts.