### PR TITLE
docs: fix typo in how-to-create-lease.md

### DIFF
--- a/content/en/docs/v3.5/tutorials/how-to-create-lease.md
+++ b/content/en/docs/v3.5/tutorials/how-to-create-lease.md
@@ -2,7 +2,7 @@
 title: How to create lease
 description: Guide to creating a lease in etcd
 weight: 700
-----
+---
 
 `lease` to write with TTL:
 


### PR DESCRIPTION
To remove an extra list mark. Removed an extra highphen of the
frontmatter.

<img width="1257" alt="extra-list" src="https://user-images.githubusercontent.com/34597587/153746280-d43b4ff2-a0b3-4400-8d03-9769115e4c8c.png">

