### PR TITLE
Rectify build script path

### DIFF
--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -52,7 +52,7 @@ source by following these steps:
  3. Run the build script:
 
     ```sh
-    $ ./build.sh
+    $ scripts/build.sh
     ```
 
     The binaries are under the `bin` directory.


### PR DESCRIPTION
In etcd source code repo, build.sh is in /scripts instead of ./