### PR TITLE
Modify the old url 

### DIFF
--- a/content/en/docs/v3.1/learning/why.md
+++ b/content/en/docs/v3.1/learning/why.md
@@ -18,5 +18,5 @@ TODO
 
 [container-linux]: https://coreos.com/why
 [etcd-concurrency]: https://pkg.go.dev/github.com/etcd-io/etcd/clientv3/concurrency
-[kubernetes]: http://kubernetes.io/docs/whatisk8s
+[kubernetes]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
 [locksmith]: https://github.com/coreos/locksmith

--- a/content/en/docs/v3.2/learning/why.md
+++ b/content/en/docs/v3.2/learning/why.md
@@ -104,7 +104,7 @@ For distributed coordination, choosing etcd can help prevent operational headach
 [etcd-v3lock]: https://pkg.go.dev/github.com/etcd-io/etcd/etcdserver/api/v3lock/v3lockpb
 [etcd-watch]: ../api/#watch-streams
 [grpc]: http://www.grpc.io
-[kubernetes]: http://kubernetes.io/docs/whatisk8s
+[kubernetes]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
 [locksmith]: https://github.com/coreos/locksmith
 [newsql-leader]: http://dl.acm.org/citation.cfm?id=2960999
 [production-users]: ../../production-users/


### PR DESCRIPTION
The url `http://kubernetes.io/docs/whatisk8s` has been changed to `https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/`,
I think we shoud to modify it

/kind cleanup