### PR TITLE
etcdserver: alter the documentation for the quota-backend-bytes variable

### DIFF
--- a/content/en/docs/v3.5/dev-guide/limit.md
+++ b/content/en/docs/v3.5/dev-guide/limit.md
@@ -10,4 +10,4 @@ etcd is designed to handle small key value pairs typical for metadata. Larger re
 
 ## Storage size limit
 
-The default storage size limit is 2GB, configurable with `--quota-backend-bytes` flag. 8GB is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
+The default storage size limit is 2GiB, configurable with `--quota-backend-bytes` flag. 8GiB is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.

--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -57,7 +57,7 @@ Flags are presented below using the format `--flag-name DEFAULT_VALUE`.
 --max-wals '5'
   Maximum number of wal files to retain (0 is unlimited).
 --quota-backend-bytes '0'
-  Raise alarms when backend size exceeds the given quota (0 defaults to low space quota).
+  Raise alarms when backend size exceeds the given quota (0 defaults to low space quota, which is 2GiB).
 --backend-bbolt-freelist-type 'map'
   BackendFreelistType specifies the type of freelist that boltdb backend uses(array and map are supported types).
 --backend-batch-interval ''
@@ -197,7 +197,7 @@ Flags are presented below using the format `--flag-name DEFAULT_VALUE`.
 --enable-log-rotation 'false'
   Enable log rotation of a single log-outputs file target.
 --log-rotation-config-json '{"maxsize": 100, "maxage": 0, "maxbackups": 0, "localtime": false, "compress": false}'
-  Configures log rotation if enabled with a JSON logger config. MaxSize(MB), MaxAge(days,0=no limit), MaxBackups(0=no limit), LocalTime(use computers local time), Compress(gzip)". 
+  Configures log rotation if enabled with a JSON logger config. MaxSize(MB), MaxAge(days,0=no limit), MaxBackups(0=no limit), LocalTime(use computers local time), Compress(gzip)".
 ```
 ### Experimental distributed tracing
 

--- a/content/en/docs/v3.6/dev-guide/limit.md
+++ b/content/en/docs/v3.6/dev-guide/limit.md
@@ -10,4 +10,4 @@ etcd is designed to handle small key value pairs typical for metadata. Larger re
 
 ## Storage size limit
 
-The default storage size limit is 2GB, configurable with `--quota-backend-bytes` flag. 8GB is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
+The default storage size limit is 2GiB, configurable with `--quota-backend-bytes` flag. 8GiB is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -57,7 +57,7 @@ Flags are presented below using the format `--flag-name DEFAULT_VALUE`.
 --max-wals '5'
   Maximum number of wal files to retain (0 is unlimited).
 --quota-backend-bytes '0'
-  Raise alarms when backend size exceeds the given quota (0 defaults to low space quota).
+  Raise alarms when backend size exceeds the given quota (0 defaults to low space quota, which is 2GiB).
 --backend-bbolt-freelist-type 'map'
   BackendFreelistType specifies the type of freelist that boltdb backend uses(array and map are supported types).
 --backend-batch-interval ''
@@ -197,7 +197,7 @@ Flags are presented below using the format `--flag-name DEFAULT_VALUE`.
 --enable-log-rotation 'false'
   Enable log rotation of a single log-outputs file target.
 --log-rotation-config-json '{"maxsize": 100, "maxage": 0, "maxbackups": 0, "localtime": false, "compress": false}'
-  Configures log rotation if enabled with a JSON logger config. MaxSize(MB), MaxAge(days,0=no limit), MaxBackups(0=no limit), LocalTime(use computers local time), Compress(gzip)". 
+  Configures log rotation if enabled with a JSON logger config. MaxSize(MB), MaxAge(days,0=no limit), MaxBackups(0=no limit), LocalTime(use computers local time), Compress(gzip)".
 ```
 ### Experimental distributed tracing
 


### PR DESCRIPTION
To be more verbose and clear out possible misunderstandings. It is best to know the exact values for flags.

Fixes #585


I haven't checked if we have this issue in other places. However, the source code also refers to the value as 2GB. 

I can edit my commit to add these lines to previous versions.