### PR TITLE
Update build script usage

### DIFF
--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -52,7 +52,7 @@ source by following these steps:
  3. Run the build script:
 
     ```sh
-    $ ./scripts/build.sh
+    $ ./build.sh
     ```
 
     The binaries are under the `bin` directory.


### PR DESCRIPTION
The build.sh was not moved to the scripts folder in 3.5 release.
