### PR TITLE
Update doc3.5 grpc_naming.md,Import the error

### DIFF
--- a/content/en/docs/v3.5/dev-guide/grpc_naming.md
+++ b/content/en/docs/v3.5/dev-guide/grpc_naming.md
@@ -12,7 +12,7 @@ The etcd client provides a gRPC resolver for resolving gRPC endpoints with an et
 
 ```go
 import (
-	"go.etcd.io/etcd/v3/clientv3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	resolver "go.etcd.io/etcd/client/v3/naming/resolver"
 
 	"google.golang.org/grpc"


### PR DESCRIPTION
-  An error occurred when I tried to use this doc

```bash
$ go mod tidy
go: finding module for package go.etcd.io/etcd/v3/clientv3
  go.etcd.io/etcd/v3/clientv3: module go.etcd.io/etcd/v3@latest found (v3.5.5), but does not contain package go.etcd.io/etcd/v3/clientv3
```

- gopkg not found 

[gopkg](https://pkg.go.dev/search?q=go.etcd.io%2Fetcd%2Fv3%2Fclientv3&m=)
[correct_gopkg](https://pkg.go.dev/go.etcd.io/etcd/client/v3)
- I modified the following and the import was normal

import (
	clientv3 "go.etcd.io/etcd/client/v3"
        ...
)
