### PR TITLE
update doc v3.5 grpc_naming.md

### DIFF
--- a/content/en/docs/v3.6/dev-guide/grpc_naming.md
+++ b/content/en/docs/v3.6/dev-guide/grpc_naming.md
@@ -12,7 +12,7 @@ The etcd client provides a gRPC resolver for resolving gRPC endpoints with an et
 
 ```go
 import (
-	"go.etcd.io/etcd/v3/clientv3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	resolver "go.etcd.io/etcd/client/v3/naming/resolver"
 
 	"google.golang.org/grpc"


### PR DESCRIPTION
The correct format  is `clientv3 "go.etcd.io/etcd/client/v3"` instead of `"go.etcd.io/etcd/clientv3"`
<img width="633" alt="image" src="https://user-images.githubusercontent.com/51436614/201075337-1d880149-3816-4e63-9a1b-9e42af5c51e0.png">