### PR TITLE
grpc_naming.md round-robin strategy

### DIFF
--- a/content/en/docs/v3.5/dev-guide/grpc_naming.md
+++ b/content/en/docs/v3.5/dev-guide/grpc_naming.md
@@ -44,6 +44,14 @@ The etcd client's `endpoints.Manager` method can also register new endpoints wit
 em := endpoints.NewManager(client, "foo/bar/my-service")
 err := em.AddEndpoint(context.TODO(),"foo/bar/my-service/e1", endpoints.Endpoint{Addr:"1.2.3.4"});
 ```
+To enable round-robin load balancing when dialing service with multiple endpoints, you can set up you connection with grpc
+ internal round-robin load balancer:
+
+ ```go
+
+ 	conn, gerr := grpc.Dial("etcd:///foo", grpc.WithResolvers(etcdResolver),
+ 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
+ ```
 
 ### Deleting an endpoint
 

--- a/content/en/docs/v3.6/dev-guide/grpc_naming.md
+++ b/content/en/docs/v3.6/dev-guide/grpc_naming.md
@@ -44,6 +44,14 @@ The etcd client's `endpoints.Manager` method can also register new endpoints wit
 em := endpoints.NewManager(client, "foo/bar/my-service")
 err := em.AddEndpoint(context.TODO(),"foo/bar/my-service/e1", endpoints.Endpoint{Addr:"1.2.3.4"});
 ```
+To enable round-robin load balancing when dialing service with multiple endpoints, you can set up you connection with grpc
+ internal round-robin load balancer:
+
+ ```go
+
+ 	conn, gerr := grpc.Dial("etcd:///foo", grpc.WithResolvers(etcdResolver),
+ 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
+ ```
 
 ### Deleting an endpoint
 


### PR DESCRIPTION
when using new resolver from, default grpc load balancing strategy: pick first will be used. It would be nice to point out how to use round-robin load balancing.

Signed-off-by: Ramil Mirhasanov <ramil600@yahoo.com>