### PR TITLE
Remove /bin/sh from Documenation

### DIFF
--- a/content/en/docs/v3.4/op-guide/container.md
+++ b/content/en/docs/v3.4/op-guide/container.md
@@ -181,7 +181,7 @@ docker run \
 To run `etcdctl` using API version 3:
 
 ```
-docker exec etcd /bin/sh -c "export ETCDCTL_API=3 && /usr/local/bin/etcdctl put foo bar"
+docker exec etcd /usr/local/bin/etcdctl put foo bar
 ```
 
 ## Bare Metal

--- a/content/en/docs/v3.5/op-guide/container.md
+++ b/content/en/docs/v3.5/op-guide/container.md
@@ -181,7 +181,7 @@ docker run \
 To run `etcdctl` using API version 3:
 
 ```
-docker exec etcd /bin/sh -c "export ETCDCTL_API=3 && /usr/local/bin/etcdctl put foo bar"
+docker exec etcd /usr/local/bin/etcdctl put foo bar
 ```
 
 ## Bare Metal

--- a/content/en/docs/v3.6/op-guide/container.md
+++ b/content/en/docs/v3.6/op-guide/container.md
@@ -181,7 +181,7 @@ docker run \
 To run `etcdctl` using API version 3:
 
 ```
-docker exec etcd /bin/sh -c "export ETCDCTL_API=3 && /usr/local/bin/etcdctl put foo bar"
+docker exec etcd /usr/local/bin/etcdctl put foo bar
 ```
 
 ## Bare Metal


### PR DESCRIPTION
Removed the reference to `\bin\sh` to accurately reflect changes in v3.7

https://github.com/etcd-io/etcd/issues/15173