### PR TITLE
Add TLS min/max version.

### DIFF
--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -166,6 +166,10 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Comma-separated whitelist of origins for CORS, or cross-origin resource sharing, (empty or * means allow all).
 --host-whitelist '*'
   Acceptable hostnames from HTTP client requests, if server is not secure (empty or * means allow all).
+--tls-min-version 'TLS1.2'
+  Minimum TLS version supported by etcd.
+--tls-max-version ''
+  Maximum TLS version supported by etcd (empty will be auto-populated by Go).
 ```
 ### Auth
 

--- a/content/en/docs/v3.6/op-guide/security.md
+++ b/content/en/docs/v3.6/op-guide/security.md
@@ -10,6 +10,8 @@ To get up and running, first have a CA certificate and a signed key pair for one
 
 For convenience, the [cfssl] tool provides an easy interface to certificate generation, and we provide an example using the tool [here][tls-setup]. Alternatively, try this [guide to generating self-signed key pairs][tls-guide].
 
+The list of flags provided below may not be up-to-date due to ongoing development changes. For the latest available flags, run `etcd --help` or refer to the [etcd help][].
+
 ## Basic setup
 
 etcd takes several certificate related configuration options, either through command-line flags or environment variables:
@@ -42,7 +44,13 @@ The peer options work the same way as the client-to-server options:
 
 If either a client-to-server or peer certificate is supplied the key must also be set. All of these configuration options are also available through the environment variables, `ETCD_CA_FILE`, `ETCD_PEER_CA_FILE` and so on.
 
-`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go). Available from v3.2.22+, v3.3.7+, and v3.4+.
+**Common options:**
+
+`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go).
+
+`--tls-min-version=<version>` Sets the minimum TLS version supported by etcd.
+
+`--tls-max-version=<version>` Sets the maximum TLS version supported by etcd. If not set the maximum version supported by Go will be used.
 
 ## Example 1: Client-to-server transport security with HTTPS
 
@@ -443,3 +451,4 @@ When etcd create certain new directories it sets file permission to 700 to preve
 [dm-crypt]: https://en.wikipedia.org/wiki/Dm-crypt
 [tls-guide]: https://github.com/coreos/docs/blob/master/os/generate-self-signed-certificates.md
 [tls-setup]: https://github.com/etcd-io/etcd/tree/master/hack/tls-setup
+[etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go


### PR DESCRIPTION
Documentation for new optional flags for setting TLS versions, which will be introduced in PR https://github.com/etcd-io/etcd/pull/15156

Signed-off-by: Tero Saarni <tero.saarni@est.tech>