### PR TITLE
Update logging.md for 3.5+ to show zap as default

### DIFF
--- a/content/en/docs/v3.5/dev-internal/logging.md
+++ b/content/en/docs/v3.5/dev-internal/logging.md
@@ -4,7 +4,7 @@ weight: 1600
 description: Logging level categories
 ---
 
-etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
+etcd uses the [zap][zap] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
 
 * Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost
   * Examples:
@@ -30,4 +30,4 @@ etcd uses the [capnslog][capnslog] library for logging application output catego
     * Send a normal message to a remote peer
     * Write a log entry to disk
 
-[capnslog]: https://github.com/coreos/pkg/tree/master/capnslog
+[zap]: https://github.com/uber-go/zap

--- a/content/en/docs/v3.6/dev-internal/logging.md
+++ b/content/en/docs/v3.6/dev-internal/logging.md
@@ -4,7 +4,7 @@ weight: 1600
 description: Logging level categories
 ---
 
-etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
+etcd uses the [zap][zap] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
 
 * Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost
   * Examples:
@@ -30,4 +30,4 @@ etcd uses the [capnslog][capnslog] library for logging application output catego
     * Send a normal message to a remote peer
     * Write a log entry to disk
 
-[capnslog]: https://github.com/coreos/pkg/tree/master/capnslog
+[zap]: https://github.com/uber-go/zap


### PR DESCRIPTION
As outlined in the blog announcing release 3.5[1] etcd now uses zap by default so we should update `logging.md` to reflect that from `v3.5` onward:

> The migration to structured logging is complete. etcd now defaults to [zap](https://github.com/uber-go/zap) logger that has a reflection-free, zero-allocation JSON encoder. We have deprecated [capnslog](https://github.com/coreos/pkg/issues/57) that logged with reflection-based serialization.

[1]https://etcd.io/blog/2021/announcing-etcd-3.5/

Fixes #605 