### PR TITLE
Update `--snapshot-count` to reflect new reduced default for 3.6+ and include new tls min/max

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -350,6 +350,14 @@ The security flags help to [build a secure etcd cluster][security].
 + default: ""
 + env variable: ETCD_CIPHER_SUITES
 
+### --tls-min-version
++ Minimum TLS version supported by etcd.
++ default: "TLS1.2"
+
+### --tls-max-version
++ Maximum TLS version supported by etcd.
++ detault: ""
+
 ## Logging flags
 
 ### --logger

--- a/content/en/docs/v3.4/op-guide/security.md
+++ b/content/en/docs/v3.4/op-guide/security.md
@@ -42,7 +42,13 @@ The peer options work the same way as the client-to-server options:
 
 If either a client-to-server or peer certificate is supplied the key must also be set. All of these configuration options are also available through the environment variables, `ETCD_CA_FILE`, `ETCD_PEER_CA_FILE` and so on.
 
-`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go). Available from v3.2.22+, v3.3.7+, and v3.4+.
+**Common options:**
+
+`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go).
+
+`--tls-min-version=<version>` Sets the minimum TLS version supported by etcd.
+
+`--tls-max-version=<version>` Sets the maximum TLS version supported by etcd. If not set the maximum version supported by Go will be used.
 
 ## Example 1: Client-to-server transport security with HTTPS
 

--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -166,6 +166,10 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Comma-separated whitelist of origins for CORS, or cross-origin resource sharing, (empty or * means allow all).
 --host-whitelist '*'
   Acceptable hostnames from HTTP client requests, if server is not secure (empty or * means allow all).
+--tls-min-version 'TLS1.2'
+  Minimum TLS version supported by etcd.
+--tls-max-version ''
+  Maximum TLS version supported by etcd (empty will be auto-populated by Go).
 ```
 ### Auth
 

--- a/content/en/docs/v3.5/op-guide/security.md
+++ b/content/en/docs/v3.5/op-guide/security.md
@@ -42,7 +42,13 @@ The peer options work the same way as the client-to-server options:
 
 If either a client-to-server or peer certificate is supplied the key must also be set. All of these configuration options are also available through the environment variables, `ETCD_CA_FILE`, `ETCD_PEER_CA_FILE` and so on.
 
-`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go). Available from v3.2.22+, v3.3.7+, and v3.4+.
+**Common options:**
+
+`--cipher-suites`: Comma-separated list of supported TLS cipher suites between server/client and peers (empty will be auto-populated by Go).
+
+`--tls-min-version=<version>` Sets the minimum TLS version supported by etcd.
+
+`--tls-max-version=<version>` Sets the maximum TLS version supported by etcd. If not set the maximum version supported by Go will be used.
 
 ## Example 1: Client-to-server transport security with HTTPS
 

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -42,7 +42,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Path to the data directory.
 --wal-dir ''
   Path to the dedicated wal directory.
---snapshot-count '100000'
+--snapshot-count '10000'
   Number of committed transactions to trigger a snapshot to disk.
 --heartbeat-interval '100'
   Time (in milliseconds) of a heartbeat interval.


### PR DESCRIPTION
1) A quick docs follow-up after https://github.com/etcd-io/etcd/pull/15408. For 3.6+ the default `--snapshot-count` has been reduced to 10,000.

Refer https://github.com/etcd-io/etcd/issues/15360

&nbsp;

2) Additionally this pull request includes documentation for tls min/max options which were recently backported to 3.5 and 3.4 so need to be added to the operations guide.

Refer:
- https://github.com/etcd-io/etcd/pull/15483
- https://github.com/etcd-io/etcd/pull/15486