### PR TITLE
Clarify linarizability regarding watch operations

### DIFF
--- a/content/en/docs/v3.6/learning/api_guarantees.md
+++ b/content/en/docs/v3.6/learning/api_guarantees.md
@@ -104,7 +104,7 @@ Watches make guarantees about events:
 
 etcd does not ensure linearizability for watch operations. The responses are
 ordered but may be stale. Users are expected to verify the revision of watch
-responses to ensure correct ordering against other operations.
+responses to ensure correct ordering with other operations.
 
 ## Lease APIs
 

--- a/content/en/docs/v3.6/learning/api_guarantees.md
+++ b/content/en/docs/v3.6/learning/api_guarantees.md
@@ -102,8 +102,9 @@ Watches make guarantees about events:
 * Bookmarkable - Progress notification events guarantee that all events up to a
   revision have been already delivered.
 
-etcd does not ensure linearizability for watch operations. Users are expected
-to verify the revision of watch events to ensure correct ordering with other operations.
+etcd does not ensure linearizability for watch operations. The responses are
+ordered but may be stale. Users are expected to verify the revision of watch
+responses to ensure correct ordering against other operations.
 
 ## Lease APIs
 


### PR DESCRIPTION
Clarifications regarding linearizability based on [this discussion](https://github.com/etcd-io/etcd/discussions/15423#discussioncomment-5238721)

I have only changed v3.6 as I am not sure how this should be handled, is it ok if I also change it for  3.5?