### PR TITLE
Use new and better canonical link to Google Groups #479

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -131,7 +131,7 @@ params:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
       - name: Google Group
-        url: https://groups.google.com/forum/?hl=en#!forum/etcd-dev
+        url: https://groups.google.com/g/etcd-dev
         icon: fab fa-google
       - name: Twitter
         url: https://twitter.com/etcdio

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -89,7 +89,7 @@ For etcd contribution guidelines, see [How to contribute][].
 </div>
 
 [@etcdio]: https://twitter.com/etcdio
-[etcd-dev]: https://groups.google.com/forum/?hl=en#!forum/etcd-dev
+[etcd-dev]: https://groups.google.com/g/etcd-dev
 [etcd-youtube]: https://www.youtube.com/channel/UC7tUWR24I5AR9NMsG-NYBlg
 [How to contribute]: https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md
 [meeting-doc]: https://docs.google.com/document/d/16XEGyPBisZvmmoIHSZzv__LoyOeluC5a4x353CX0SIM


### PR DESCRIPTION
Signed-off-by : Sajjan Yadav sajjan28yadav@gmail.com

All the older links are replaced by new one as stated in issue #479 