### PR TITLE
Remove --discovery-srv-name docs from releases that don't support it

### DIFF
--- a/content/en/docs/v2.3/clustering.md
+++ b/content/en/docs/v2.3/clustering.md
@@ -289,13 +289,6 @@ To help clients discover the etcd cluster, the following DNS SRV records are loo
 
 If `_etcd-client-ssl._tcp.example.com` is found, clients will attempt to communicate with the etcd cluster over SSL.
 
-The `-discovery-srv-name` flag additionally configures a suffix to the SRV name that is queried during discovery.
-Use this flag to differentiate between multiple etcd clusters under the same domain.
-For example, if `discovery-srv=example.com` and `-discovery-srv-name=foo` are set, the following DNS SRV queries are made:
-
-* _etcd-server-ssl-foo._tcp.example.com
-* _etcd-server-foo._tcp.example.com
-
 #### Create DNS SRV records
 
 ```

--- a/content/en/docs/v2.3/configuration.md
+++ b/content/en/docs/v2.3/configuration.md
@@ -124,11 +124,6 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: none
 + env variable: ETCD_DISCOVERY_SRV
 
-### --discovery-srv-name
-+ Suffix to the DNS srv name queried when bootstrapping using DNS.
-+ default: none
-+ env variable: ETCD_DISCOVERY_SRV_NAME
-
 ### --discovery-fallback
 + Expected behavior ("exit" or "proxy") when discovery services fails.
 + default: "proxy"

--- a/content/en/docs/v3.3/op-guide/clustering.md
+++ b/content/en/docs/v3.3/op-guide/clustering.md
@@ -367,13 +367,6 @@ If etcd is using TLS, the discovery SRV record (e.g. `example.com`) must be incl
 
 If etcd is using TLS without a custom certificate authority, the discovery domain (e.g., example.com) must match the SRV record domain (e.g., infra1.example.com). This is to mitigate attacks that forge SRV records to point to a different domain; the domain would have a valid certificate under PKI but be controlled by an unknown third party.
 
-The `-discovery-srv-name` flag additionally configures a suffix to the SRV name that is queried during discovery.
-Use this flag to differentiate between multiple etcd clusters under the same domain.
-For example, if `discovery-srv=example.com` and `-discovery-srv-name=foo` are set, the following DNS SRV queries are made:
-
-* _etcd-server-ssl-foo._tcp.example.com
-* _etcd-server-foo._tcp.example.com
-
 #### Create DNS SRV records
 
 ```

--- a/content/en/docs/v3.3/op-guide/configuration.md
+++ b/content/en/docs/v3.3/op-guide/configuration.md
@@ -170,11 +170,6 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: ""
 + env variable: ETCD_DISCOVERY_SRV
 
-### --discovery-srv-name
-+ Suffix to the DNS srv name queried when bootstrapping using DNS.
-+ default: ""
-+ env variable: ETCD_DISCOVERY_SRV_NAME
-
 ### --discovery-fallback
 + Expected behavior ("exit" or "proxy") when discovery services fails. "proxy" supports v2 API only.
 + default: "proxy"


### PR DESCRIPTION
This pull request fixes our oldest open docs issue which relates to the etcd server parameter `--discovery-srv-name`.

Our docs for 2.3 and 3.3 currently indicate that the option exists and can be used but as per the discussion in https://github.com/etcd-io/etcd/issues/10916 the option is not available.

I've verified this manually by downloading the latest 2.3 and 3.3 releases and confirming the option is not present:

```bash
 ~  D  etcd-v2.3.8-linux-amd64  ./etcd --version
etcd Version: 2.3.8
Git SHA: 7e4fc7e
Go Version: go1.7.5
Go OS/Arch: linux/amd64

 ~  D  etcd-v2.3.8-linux-amd64  ./etcd --discovery-srv-name
flag provided but not defined: -discovery-srv-name
````

```bash
 ~  D  etcd-v3.3.27-linux-amd64  ./etcd --version
etcd Version: 3.3.27
Git SHA: 973882f69
Go Version: go1.12.17
Go OS/Arch: linux/amd64

 ~  D  etcd-v3.3.27-linux-amd64  ./etcd --discovery-srv-name
flag provided but not defined: -discovery-srv-name
```

We can compare this to 3.4 onwards which supports the option:
```bash
 ~  Documents  etcd   release-3.4  ./bin/etcd --version
etcd Version: 3.4.24
Git SHA: d8f7cfe28
Go Version: go1.19.7
Go OS/Arch: linux/amd64

 ~  Documents  etcd   release-3.4  ./bin/etcd --discovery-srv-name
flag needs an argument: -discovery-srv-name
```

So all we need to do is remove references to the option in the older releases.

Fixes #40