### PR TITLE
Fix instructions for installing goreman

### DIFF
--- a/content/en/docs/v3.4/dev-guide/local_cluster.md
+++ b/content/en/docs/v3.4/dev-guide/local_cluster.md
@@ -52,7 +52,7 @@ A `Procfile` at the base of the etcd git repository is provided to easily config
 1. Install `goreman` to control Procfile-based applications:
 
     ```
-    $ go get github.com/mattn/goreman
+    $ go install github.com/mattn/goreman@latest
     ```
 
 2. Start a cluster with `goreman` using etcd's stock Procfile:

--- a/content/en/docs/v3.5/dev-guide/local_cluster.md
+++ b/content/en/docs/v3.5/dev-guide/local_cluster.md
@@ -52,7 +52,7 @@ A `Procfile` at the base of the etcd git repository is provided to easily config
 1. Install `goreman` to control Procfile-based applications:
 
     ```
-    $ go get github.com/mattn/goreman
+    $ go install github.com/mattn/goreman@latest
     ```
 
 2. Start a cluster with `goreman` using etcd's stock Procfile:

--- a/content/en/docs/v3.6/dev-guide/local_cluster.md
+++ b/content/en/docs/v3.6/dev-guide/local_cluster.md
@@ -52,7 +52,7 @@ A `Procfile` at the base of the etcd git repository is provided to easily config
 1. Install `goreman` to control Procfile-based applications:
 
     ```
-    $ go get github.com/mattn/goreman
+    $ go install github.com/mattn/goreman@latest
     ```
 
 2. Start a cluster with `goreman` using etcd's stock Procfile:


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead. Refer: https://go.dev/doc/go-get-install-deprecation 

Fixes #563