### PR TITLE
Prefer github discussions as etcd question channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -136,9 +136,9 @@ params:
       - name: Twitter
         url: https://twitter.com/etcdio
         icon: fab fa-twitter
-      - name: Stack Overflow
-        url: https://stackoverflow.com/questions/tagged/etcd
-        icon: fab fa-stack-overflow
+      - name: Github Discussions
+        url: https://github.com/etcd-io/etcd/discussions
+        icon: fab fa-github
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: Etcd on GitHub

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -12,9 +12,9 @@ main_channels:
     desc: >
       Follow us at [@etcdio][] for real-time announcements, blogs posts, and more.
   - title: >
-      [<i class="fab fa-stack-overflow"></i>Stack Overflow][SO]
+      [<i class="fab fa-github"></i>Github Discussions][GD]
     desc: >
-      Ask and find answers to your etcd technical questions.
+      Ask and find answers to your etcd questions.
 community_resources:
   - title: >
       [<i class="fab fa-google"></i>Google Meet][online]
@@ -95,4 +95,4 @@ For etcd contribution guidelines, see [How to contribute][].
 [meeting-doc]: https://docs.google.com/document/d/16XEGyPBisZvmmoIHSZzv__LoyOeluC5a4x353CX0SIM
 [online]: https://meet.google.com/umg-nrxn-qvs
 [Pacific Time]: https://www.timeanddate.com/time/zones/pt
-[SO]: https://stackoverflow.com/questions/tagged/etcd
+[GD]: https://github.com/etcd-io/etcd/discussions


### PR DESCRIPTION
On our website [community page](https://github.com/etcd-io/website/issues/680) we currently encourage users to ask etcd questions on stack overflow.

This is not a channel I actively monitor and I am guessing most other etcd contributors are not monitoring it either. We have limited time available to answer questions and currently are only just managing to keep on top of questions asked in our [github discussions](https://github.com/etcd-io/etcd/discussions).

To limit how many channels we need to monitor let's just suggest users open questions via github discussions.

Additionally this prevents friction where non code etcd questions are simply closed on stack overflow without any help provided, refer example https://stackoverflow.com/questions/76228295/can-i-recover-etcd-from-the-db-file.

Fixes #680