### PR TITLE
Added portworx to projects using etcd.

### DIFF
--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -196,3 +196,4 @@ The sections below list etcd client libraries by language.
 - [Trillian](https://github.com/google/trillian) - Trillian implements a Merkle tree whose contents are served from a data storage layer, to allow scalability to extremely large trees.
 - [Apache APISIX](https://github.com/apache/apisix) - Apache APISIX is a dynamic, real-time, high-performance API gateway.
 - [purpleidea/mgmt](https://github.com/purpleidea/mgmt) - Next generation distributed, event-driven, parallel config management!
+- [Portworx/kvdb](https://docs.portworx.com/concepts/internal-kvdb/) - The internal kvdb for storing Portworx cluster configuration.

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -197,3 +197,4 @@ The sections below list etcd client libraries by language.
 - [Trillian](https://github.com/google/trillian) - Trillian implements a Merkle tree whose contents are served from a data storage layer, to allow scalability to extremely large trees.
 - [Apache APISIX](https://github.com/apache/apisix) - Apache APISIX is a dynamic, real-time, high-performance API gateway.
 - [purpleidea/mgmt](https://github.com/purpleidea/mgmt) - Next generation distributed, event-driven, parallel config management!
+- [Portworx/kvdb](https://docs.portworx.com/concepts/internal-kvdb/) - The internal kvdb for storing Portworx cluster configuration.


### PR DESCRIPTION
Portworx are using etcd for their internal kvdb, adding a co-authored commit to list them as a project using etcd.

This pr was created from a pair session with Portworx team members @gschultzy and @jaikritnegi during a Wellington CNCF meetup.

Reference: https://docs.portworx.com/concepts/internal-kvdb