### PR TITLE
Remove python library etcd3-gateway

### DIFF
--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -63,7 +63,6 @@ The sections below list etcd client libraries by language.
 - [cholcombe973/autodock](https://github.com/cholcombe973/autodock) - A docker deployment automation tool
 - [lisael/aioetcd](https://github.com/lisael/aioetcd) - (Python 3.4+) Asyncio coroutines client (Supports v2)
 - [txaio-etcd](https://github.com/crossbario/txaio-etcd) - Asynchronous etcd v3-only client library for Twisted (today) and asyncio (future)
-- [dims/etcd3-gateway](https://github.com/dims/etcd3-gateway) - etcd v3 API library using the HTTP grpc gateway
 - [aioetcd3](https://github.com/gaopeiliang/aioetcd3) - (Python 3.6+) etcd v3 API for asyncio
 - [Revolution1/etcd3-py](https://github.com/Revolution1/etcd3-py) - (python2.7 and python3.5+) Python client for etcd v3, using gRPC-JSON-Gateway
 


### PR DESCRIPTION
According to https://github.com/dims/etcd3-gateway the library is not maintained anymore and the repo is listed as a "Public archive". So I'd suggest removing it from the official recommended integrations/libraries.