### PR TITLE
 Confirm maintainership for etcd website

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,24 @@
+# The official list of maintainers and reviewers for the project maintenance.
+#
+# Refer to https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/community-membership.md
+# for a description of these roles.
+#
+# Names should be added to this file like so:
+#     Individual's name <submission email address> (@GITHUB_HANDLE) *
+#     Individual's name <submission email address> <email2> <emailN> (@GITHUB_HANDLE) *
+#
+# Please keep the list sorted.
+
+# MAINTAINERS
+Benjamin Wang <wachao@vmware.com> (ahrtr@) *
+Hitoshi Mitake <h.mitake@gmail.com> (@mitake) *
+Josh Berkus <jberkus@redhat.com> (@jberkus) *
+Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com> (@serathius) *
+Nate W. <natew@cncf.io> (@nate-double-u) *
+Patrice Chalin <chalin@cncf.io> (@chalin) *
+Piotr Tabor <piotr.tabor@gmail.com> (@ptabor) *
+Sahdev Zala <spzala@us.ibm.com> (@spzala) *
+Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com> (@wenjiaswe) *
+
+# REVIEWERS
+James Blair <jablair@redhat.com> <mail@jamesblair.net> (@jmhbnz) *


### PR DESCRIPTION
Currently it is not fully clear who is an etcd website maintainer because:

- our github etcd maintainers-website team does not have any members populated, refer: https://github.com/orgs/etcd-io/teams/maintainers-website
- there is no `MAINTAINERS` file included at the root level of this repo.

This can create friction for pull requests because contributors don't know who they need to ping if they have questions or want help.

As a starting point I propose we include a `MAINTAINERS` file specifying all members of `etcd-io/maintainers-etcd`  as website maintainers.

Relates to https://github.com/etcd-io/website/issues/679