### PR TITLE
CI: fix get-link-checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,6 @@ check-links: $(GET_LINK_CHECKER_IF_NEEDED)
 docker-serve:
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMG) server $(DRAFT_ARGS)
 
-# Until htmltext >0.14.x is released, get and build our own from source:
 get-link-checker:
-	rm -Rf $(HTMLTEST_DIR)
-	mkdir -p $(HTMLTEST_DIR)/bin && \
-	cd $(HTMLTEST_DIR) && \
-	git clone --depth=1 https://github.com/wjdp/htmltest.git && \
-	( \
-		cd htmltest && \
-		./build.sh && \
-		cp bin/htmltest ../bin \
-	)
-
-# Once htmltext >0.14.x is released, replace the get-and-build code above with this:
-# get-link-checker:
-# 	rm -Rf $(HTMLTEST_DIR)/bin
-# 	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin
+	rm -Rf $(HTMLTEST_DIR)/bin
+	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin


### PR DESCRIPTION
- Closes #692

---

Preview builds are passing now, e.g. https://app.netlify.com/teams/etcd/builds/647e2c214796fa000812df6a:

> <img width="600" alt="image" src="https://github.com/etcd-io/website/assets/4140793/8f2aa4cc-356f-4ed3-bbbd-5038e4d2b7b3">

/cc @jmhbnz