### PR TITLE
Mark arm64 as a tier1 supported platform for v3.5 and v3.6

### DIFF
--- a/content/en/docs/v3.5/op-guide/supported-platform.md
+++ b/content/en/docs/v3.5/op-guide/supported-platform.md
@@ -10,14 +10,13 @@ etcd runs on different platforms, but the guarantees it provides depends on a
 platform's support tier:
 
 - **Tier 1**: fully supported by [etcd maintainers][]; etcd is guaranteed to
-  pass all tests including functional and stress tests.
+  pass all tests including functional and robustness tests.
 - **Tier 2**: etcd is guaranteed to pass integration and end-to-end tests but
-  not necessarily functional or stress tests.
+  not necessarily functional or robustness tests.
 - **Tier 3**: etcd is guaranteed to build, may be lightly tested (or not), and
   so it should be considered _unstable_.
 
 ## Current support
-
 
 The following table lists currently supported platforms and their corresponding
 etcd support tier:
@@ -25,7 +24,7 @@ etcd support tier:
 | Architecture | Operating system | Support tier |     Maintainers      |
 |:------------:|:----------------:|:------------:|:--------------------:|
 | AMD64        | Linux            |      1       | [etcd maintainers][] |
-| ARM64        | Linux            |      3       |                      |
+| ARM64        | Linux            |      1       | [etcd maintainers][] |
 | AMD64        | Darwin           |      3       |                      |
 | AMD64        | Windows          |      3       |                      |
 | ARM          | Linux            |      3       |                      |
@@ -47,7 +46,7 @@ tier:
 | Build passes                          | &check;| &check;| &check;|
 | Unit tests pass                       | &check;| &check;|        |
 | Integration and end-to-end tests pass | &check;| &check;|        |
-| Functional and stress tests pass      | &check;|        |        |
+| Robustness tests pass                 | &check;|        |        |
 
 For an example of setting up tier-2 CI for ARM64, see [etcd PR #12928][].
 

--- a/content/en/docs/v3.6/op-guide/supported-platform.md
+++ b/content/en/docs/v3.6/op-guide/supported-platform.md
@@ -10,14 +10,13 @@ etcd runs on different platforms, but the guarantees it provides depends on a
 platform's support tier:
 
 - **Tier 1**: fully supported by [etcd maintainers][]; etcd is guaranteed to
-  pass all tests including functional and stress tests.
+  pass all tests including functional and robustness tests.
 - **Tier 2**: etcd is guaranteed to pass integration and end-to-end tests but
-  not necessarily functional or stress tests.
+  not necessarily functional or robustness tests.
 - **Tier 3**: etcd is guaranteed to build, may be lightly tested (or not), and
   so it should be considered _unstable_.
 
 ## Current support
-
 
 The following table lists currently supported platforms and their corresponding
 etcd support tier:
@@ -25,7 +24,7 @@ etcd support tier:
 | Architecture | Operating system | Support tier |     Maintainers      |
 |:------------:|:----------------:|:------------:|:--------------------:|
 | AMD64        | Linux            |      1       | [etcd maintainers][] |
-| ARM64        | Linux            |      3       |                      |
+| ARM64        | Linux            |      1       | [etcd maintainers][] |
 | AMD64        | Darwin           |      3       |                      |
 | AMD64        | Windows          |      3       |                      |
 | ARM          | Linux            |      3       |                      |
@@ -42,12 +41,12 @@ addition to committing to support the platform, you must setup etcd continuous
 integration (CI) satisfying the following requirements, depending on the support
 tier:
 
-| etcd continuous integration           | Tier 1 | Tier 2 | Tier 3 |
-| ------------------------------------- |:------:|:------:|:------:|
-| Build passes                          | &check;| &check;| &check;|
-| Unit tests pass                       | &check;| &check;|        |
-| Integration and end-to-end tests pass | &check;| &check;|        |
-| Functional and stress tests pass      | &check;|        |        |
+| etcd continuous integration           | Tier 1  | Tier 2  | Tier 3  |
+|---------------------------------------|:-------:|:-------:|:-------:|
+| Build passes                          | &check; | &check; | &check; |
+| Unit tests pass                       | &check; | &check; |         |
+| Integration and end-to-end tests pass | &check; | &check; |         |
+| Robustness tests pass                 | &check; |         |         |
 
 For an example of setting up tier-2 CI for ARM64, see [etcd PR #12928][].
 


### PR DESCRIPTION
Now that we have completed the items under https://github.com/etcd-io/etcd/issues/15951 that relate to `arm64` I believe we have a lot more confidence about supporting `arm64` moving forward and are ready to mark it as tier 1 supported for `release-3.5` forward.

To recap, the headline items completed were:
- Making our `arm64` tests on self hosted runners more reliable by running them within containers.
- Ensuring all test suites including robustness and e2e release are run on `arm64`.
- Running arm64 tests against `release-3.5` in addition to `main`.
- Creating documentation to outline how our `arm64` infrastructure is managed.


I can see we now have green across the board and for several days for:
- Integration Arm64 Nightly for both `main` and `release-3.5`: https://github.com/etcd-io/etcd/actions/workflows/tests-arm64-nightly.yaml
- E2E Arm64 Nightly for both `main` and `release-3.5`: https://github.com/etcd-io/etcd/actions/workflows/e2e-arm64-nightly.yaml
- Robustness Arm64 Nightly for both `main` and `release-35`: https://github.com/etcd-io/etcd/actions/workflows/robustness-nightly.yaml

Moving forward I intend to continue keeping an eye on these and am happy to help resolve any issues that emerge.

Many thanks to the numerous contributors that supported this planned improvement work.  Once this merges we can consider sending a proper announcement on mailing list and/or slack.

Note: There is some further work in the plan to continue improving etcd ci and our self hosted runners however I don't believe these items are blockers for announcing `arm64` t1.

