### PR TITLE
Add etcd-diagnosis into the tool list

### DIFF
--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -23,6 +23,7 @@ description: A listing of etcd tools and client libraries
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcd-defrag](https://github.com/ahrtr/etcd-defrag) - An easier to use and smarter etcd defragmentation tool.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-diagnosis](https://github.com/ahrtr/etcd-diagnosis) - A comprehensive tool for etcd diagnosis.
 
 ## Libraries
 

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -23,6 +23,7 @@ description: A listing of etcd tools and client libraries
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcd-defrag](https://github.com/ahrtr/etcd-defrag) - An easier to use and smarter etcd defragmentation tool.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-diagnosis](https://github.com/ahrtr/etcd-diagnosis) - A comprehensive tool for etcd diagnosis.
 
 ## Libraries
 


### PR DESCRIPTION
[etcd-diagnosis](https://github.com/ahrtr/etcd-diagnosis) is an one-stop etcd diagnosis tool. It diagnoses running etcd clusters and generates a report with just one command.