### PR TITLE
revert the change in PR 698: add https://github.com/microsoft/etcd3 back

### DIFF
--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -70,6 +70,7 @@ The sections below list etcd client libraries by language.
 
 ### Node
 
+- [mixer/etcd3](https://github.com/mixer/etcd3) - Supports v3
 - [stianeikeland/node-etcd](https://github.com/stianeikeland/node-etcd) - Supports v2 (w Coffeescript)
 - [lavagetto/nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) - Supports v2
 - [deedubs/node-etcd-config](https://github.com/deedubs/node-etcd-config) - Supports v2

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -71,6 +71,7 @@ The sections below list etcd client libraries by language.
 
 ### Node
 
+- [mixer/etcd3](https://github.com/mixer/etcd3) - Supports v3
 - [stianeikeland/node-etcd](https://github.com/stianeikeland/node-etcd) - Supports v2 (w Coffeescript)
 - [lavagetto/nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) - Supports v2
 - [deedubs/node-etcd-config](https://github.com/deedubs/node-etcd-config) - Supports v2


### PR DESCRIPTION
Revert the change in https://github.com/etcd-io/website/pull/698.

The library has 467 stars, and used by 437 users. It makes sense to keep it for now.

cc @spzala @jmhbnz @connor4312