### PR TITLE
Use top-nav search bar only on desktop

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -98,8 +98,7 @@ params:
   # User interface configuration
   ui:
     sidebar_menu_compact: true
-    breadcrumb_disable: false
-    sidebar_search_disable: false
+    sidebar_search_disable: true
     navbar_logo: true
     footer_about_disable: true
     navbar_translucent_over_cover_disable: true


### PR DESCRIPTION
- Closes #499
- **Preview**: https://deploy-preview-716--etcd.netlify.app/docs/latest
- Notes:
  - This hides the second search-box from the left side nav on desktop
  - On tablet, there's only one search-box, and it's (still) in the left side nav
  - On mobile, the top-of-page search-box is still there