### PR TITLE
Rename community meeting tile

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -17,7 +17,7 @@ main_channels:
       Ask and find answers to your etcd questions.
 community_resources:
   - title: >
-      [<i class="fab fa-google"></i>Google Meet][online]
+      [<i class="fab"></i>Zoom Meeting][online]
     desc: >
       Join contributors and maintainers [online][], every two weeks.
   - title: >


### PR DESCRIPTION
In https://github.com/etcd-io/website/pull/714 we updated the url for our community meetings from google meets to our new CNCF zoom link.

I just noticed there is actually also a tile header that was still saying Google Meet and also needing to be updated.