### PR TITLE
Added note that --trusted-ca-file also enables client cert authentication

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -291,6 +291,7 @@ The security flags help to [build a secure etcd cluster][security].
 + Path to the client server TLS trusted CA cert file.
 + default: ""
 + env variable: ETCD_TRUSTED_CA_FILE
++ Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
 
 ### --auto-tls
 + Client TLS using generated certificates

--- a/content/en/docs/v3.4/upgrades/upgrade_3_4.md
+++ b/content/en/docs/v3.4/upgrades/upgrade_3_4.md
@@ -56,6 +56,8 @@ Other HTTP APIs will still work (e.g. `[CLIENT-URL]/metrics`, `[CLIENT-URL]/heal
 
 `--ca-file` and `--peer-ca-file` flags are deprecated; they have been deprecated since v2.1.
 
+Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
+
 ```diff
 -etcd --ca-file ca-client.crt
 +etcd --trusted-ca-file ca-client.crt

--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -140,6 +140,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Allowed TLS hostname for client cert authentication.
 --trusted-ca-file ''
   Path to the client server TLS trusted CA cert file.
+  Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
 --auto-tls 'false'
   Client TLS using generated certificates.
 --peer-cert-file ''

--- a/content/en/docs/v3.5/upgrades/upgrade_3_4.md
+++ b/content/en/docs/v3.5/upgrades/upgrade_3_4.md
@@ -56,6 +56,8 @@ Other HTTP APIs will still work (e.g. `[CLIENT-URL]/metrics`, `[CLIENT-URL]/heal
 
 `--ca-file` and `--peer-ca-file` flags are deprecated; they have been deprecated since v2.1.
 
+Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
+
 ```diff
 -etcd --ca-file ca-client.crt
 +etcd --trusted-ca-file ca-client.crt

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -140,6 +140,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Allowed TLS hostname for client cert authentication.
 --trusted-ca-file ''
   Path to the client server TLS trusted CA cert file.
+  Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
 --auto-tls 'false'
   Client TLS using generated certificates.
 --peer-cert-file ''

--- a/content/en/docs/v3.6/upgrades/upgrade_3_4.md
+++ b/content/en/docs/v3.6/upgrades/upgrade_3_4.md
@@ -56,6 +56,8 @@ Other HTTP APIs will still work (e.g. `[CLIENT-URL]/metrics`, `[CLIENT-URL]/heal
 
 `--ca-file` and `--peer-ca-file` flags are deprecated; they have been deprecated since v2.1.
 
+Note setting this parameter will also automatically enable client cert authentication no matter what value is set for `--client-cert-auth`.
+
 ```diff
 -etcd --ca-file ca-client.crt
 +etcd --trusted-ca-file ca-client.crt


### PR DESCRIPTION
This pull request updates our standard configuration documentation and 3.3 - 3.4 upgrade documentation to make it clear setting `--trusted-ca-file` also enables client cert authentication. 

Refer to discussion: https://github.com/etcd-io/etcd/issues/11124 and also PR: https://github.com/etcd-io/etcd/pull/16585 

CC: @ahrtr 