### PR TITLE
Add OWNERS file for etcd website

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
+  - mitake          # Hitoshi Mitake <h.mitake@gmail.com>
+  - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
+  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
+  - spzala          # Sahdev Zala <spzala@us.ibm.com>
+  - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
+  - jberkus         # Josh Berkus <jberkus@redhat.com>
+  - nate-double-u   # Nate W. <natew@cncf.io>
+  - chalin          # Patrice Chalin <chalin@cncf.io>
+reviewers:
+  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>


### PR DESCRIPTION
Sub-task of https://github.com/etcd-io/etcd/issues/16367.

This pull request proposes a layout for the OWNERS file we need to add to each non archived subproject under the etcd-io github organisation as part of the creation of sig-etcd.

Refer to OWNERS documentation: https://www.kubernetes.dev/docs/guide/owners

Note: Once the sig comes online fully and we shift to managing org membership through the kubernetes org bot then we need to consider a follow-up pull request to prune out the old MAINTAINERS file approach.