### PR TITLE
Update dependencies to resolve vulnerabilities

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+---
 baseURL: https://etcd.io
 enableRobotsTxt: true
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "submodule:update": "git submodule update --remote --recursive --depth 1"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.89.4",
-    "netlify-cli": "^7.0.0",
-    "postcss": "^8.3.11",
-    "postcss-cli": "^9.0.2"
+    "autoprefixer": "^10.4.16",
+    "hugo-extended": "^0.101.0",
+    "netlify-cli": "^16.6.1",
+    "postcss": "^8.4.31",
+    "postcss-cli": "^10.1.0"
   }
 }


### PR DESCRIPTION
Currently based on the dependencies in `package.json` we see an `npm audit` summary as follows:

```bash
46 vulnerabilities (1 low, 21 moderate, 23 high, 1 critical)
```

With this pr we are in a much better position:

```bash
3 moderate severity vulnerabilities
```

This pr is a step of progress towards https://github.com/etcd-io/website/issues/717.