### PR TITLE
Add kubecon na 2023 page

### DIFF
--- a/content/en/blog/2023/engage_with_etcd_at_kccncna2023.md
+++ b/content/en/blog/2023/engage_with_etcd_at_kccncna2023.md
@@ -1,0 +1,46 @@
+---
+title: Engage with the etcd project at KubeCon NA 2023
+author:  "[James Blair](https://github.com/jmhbnz), Red Hat"
+date: 2023-10-19
+draft: true
+---
+
+KubeCon NA 2023 in Chicago is just around the corner! This year, the etcd project has a diverse range of talks, tutorials, and even interactive contribfest sessions for you to get involved in . As a critical foundational pillar of the Kubernetes ecosystem, etcd's presence at Kubecon underscores its importance in ensuring all our Kubernetes clusters continue to have robust and reliable distributed persistent state.
+
+Here's a detailed overview of what you can expect from the Etcd Project's presence at KubeCon NA 2023:
+
+## 1. Schedule of talks
+
+Below is a list of talks on etcd, you can add these to your custom agenda by clicking the links for each talk through to <https://kccncna2023.sched.com>.
+
+| **Talk Title**                                                                                           | **Speakers**                                                   | **Date & Time (CST)**          |
+|----------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|--------------------------------|
+| **[Journey Through Time: Understanding Etcd Revisions and Resource Versions in Kubernetes](https://kccncna2023.sched.com/event/1R2m8/journey-through-time-understanding-etcd-revisions-and-resource-versions-in-kubernetes-priyanka-saggu-suse)**               | Priyanka Saggu, SUSE                                           | Tuesday, November 7, 11:00am   |
+| **[Mastering Etcd Observability: A Comprehensive Guide to Metrics, Monitoring, and Incident Handling](https://kccncna2023.sched.com/event/1R2rD/tutorial-mastering-etcd-observability-a-comprehensive-guide-to-metrics-monitoring-and-incident-handling-bogdan-kanivets-vivek-patani-apple)**    | Bogdan Kanivets & Vivek Patani, Apple                          | Wednesday, November 8, 2:30pm  |
+| **[Forging a Stronger Bond Between Etcd and Kubernetes](https://kccncna2023.sched.com/event/1R2rt/forging-a-stronger-bond-between-etcd-and-kubernetes-marek-siarkowicz-wenjia-zhang-google-james-blair-red-hat)**                                                  | Marek Siarkowicz & Wenjia Zhang, Google; James Blair, Red Hat  | Wednesday, November 8, 3:25pm  |
+| **[Insights and Gotchas from the Zero-Downtime Migration of 10000+ Cloud Hosted Etcd Key-Value Stores](https://kccncna2023.sched.com/event/1R2tG/insights-and-gotchas-from-the-zero-downtime-migration-of-10000-cloud-hosted-etcd-key-value-stores-prabhakar-palanivel-oracle-corporation)**   | Prabhakar Palanivel, Oracle Corporation                        | Thursday, November 9, 11:00am  |
+| **[Secrets of Running Etcd](https://kccncna2023.sched.com/event/1R2vl/secrets-of-running-etcd-marek-siarkowicz-google)**                                                                              | Marek Siarkowicz, Google                                       | Thursday, November 9, 4:00pm   |
+
+## 2. Contribfest - Learn from the maintainers and get involved
+
+Join the etcd contributor community at this [hands on session](https://kccncna2023.sched.com/event/1R2p2/contribfest-etcd-learn-from-the-maintainers-and-get-involved-marek-siarkowicz-wenjia-zhang-google-james-blair-josh-berkus-red-hat). We'll be working on improving key features and testing for Etcd, and in the process we’ll teach those new to the project how to contribute. Etcd welcomes both new contributors and those who want to “level up”. Attendees should be familiar with programming in Go, using GitHub, and should bring a laptop on which they can do cloud-native development: either a Linux laptop or your own Github Devcontainer setup.
+
+- **Facillitators:** Marek Siarkowicz & Wenjia Zhang, Google; James Blair & Josh Berkus, Red Hat
+- **Date & Time:** Tuesday, November 7, 4:30pm CST
+
+## 3. Project pavilion booth: Meet the etcd team
+
+Along with the engaging sessions above, the Etcd Project will also be staffing a booth in the project pavilion. This is a fantastic opportunity for you to interact directly with the etcd team, ask questions, and learn more about the project's latest developments. Whether you are a beginner exploring the world of Kubernetes or an experienced developer seeking insights into etcd's intricacies, the etcd project's booth is the place to stop by, say hello and ask any questions you might have.
+
+## 4. SIG-etcd meet and greet
+
+Lastly, on Thursday, November 9 from 12:00pm - 3:00pm the SIG-etcd team will have a table at the [Meet the Kubernetes Contributor Community](https://github.com/kubernetes/community/issues/7541) event. If you have questions specifically about the new etcd kubernetes special interest group please stop by.
+
+
+## We hope to see you there
+
+Don't miss these opportunities to enhance your understanding of etcd and the pivotal role it plays in our Kubernetes ecosystem. Join us at KubeCon NA 2023 in Chicago, and let's explore the possibilities of etcd together!
+
+---
+
+*Note: Schedule and session details are subject to change. Please refer to the [official KubeCon NA 2023 schedule](https://kccncna2023.sched.com) for the most up-to-date information.*

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -35,6 +35,7 @@ docs/v3.4.0/reporting-bugs    /docs/v3.4.0/reporting_bugs/
 /docs/next/learning/lock/*  /docs/next/learning/why/#notes-on-the-usage-of-lock-and-lease
 
 /blog/jepsen-343-results  /blog/2020/jepsen-343-results/
+/kubecon    /blog/2023/engage_with_etcd_at_kccncna2023
 
 /docs/next/dl-build  /docs/next/install/
 /docs/v3.4/dl-build  /docs/v3.4/install/


### PR DESCRIPTION
During the opening keynotes of KubeCon NA 2023 in Chicago there will be a short video played (recorded by @wenjiaswe) for the etcd project update.

The video has four slides. On each slide is the qr code pointing to [etcd.io/kubecon](https://etcd.io/kubecon) and after covering the main content on the slides the audio will direct the audience to scan the qr code or go to the url for a summary of how they can engage with the project at the conference.

This pull request creates a basic blog page outlining how attendees can engage with the etcd project during the conference and I have updated `layouts/index.redirects` to include the matching url that the qr code / shortlink has.

---

Note for reviewers - I welcome your feedback now however we can hold off merging until closer to the event.