### PR TITLE
Bump hugo-extended from 0.101.0 to 0.110.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
-    "hugo-extended": "^0.101.0",
+    "hugo-extended": "^0.110.0",
     "netlify-cli": "^16.6.1",
     "postcss": "^8.4.31",
     "postcss-cli": "^10.1.0"


### PR DESCRIPTION
Next incremental step of progress for https://github.com/etcd-io/website/issues/717.