### PR TITLE
docs: update broken links, fix outdated links

### DIFF
--- a/content/en/docs/v3.1/libraries-and-tools.md
+++ b/content/en/docs/v3.1/libraries-and-tools.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.1/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 
 **Java libraries**

--- a/content/en/docs/v3.2/integrations.md
+++ b/content/en/docs/v3.2/integrations.md
@@ -20,8 +20,8 @@ title: Libraries and tools
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.2/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/en/docs/v3.3/integrations.md
+++ b/content/en/docs/v3.3/integrations.md
@@ -22,8 +22,8 @@ weight: 2
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.3/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -27,8 +27,8 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 
 **Go libraries**
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.4/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -32,7 +32,7 @@ The sections below list etcd client libraries by language.
 
 ### Go
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/release-3.5/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
 - [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.5/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.

--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -32,8 +32,8 @@ The sections below list etcd client libraries by language.
 
 ### Go
 
-- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/master/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/master/client/v2) - the officially maintained Go client for v2
+- [etcd/client/v3](https://github.com/etcd-io/etcd/tree/release-3.5/client/v3) - the officially maintained Go client for v3
+- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.5/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -33,7 +33,6 @@ The sections below list etcd client libraries by language.
 ### Go
 
 - [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
-- [etcd/client/v2](https://github.com/etcd-io/etcd/tree/main/client/v2) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 


### PR DESCRIPTION
Hello,

Here is a PR to update some broken links in 3.5 integration [documentation](https://etcd.io/docs/v3.5/integrations/).

For versions 3.4 and earlier - I am not sure but I think `etcd/client/v3` should be removed? If my understanding is correct, client v3 only came out with etcd 3.5, so it might be a good idea to not list it in the docs for earlier versions.

Let me know what you think!