### PR TITLE
Update doc to `–client-cert-auth`: it's recommended to enable this flag to avoid abuse of http2 for unauthenticated clients

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -275,7 +275,7 @@ The security flags help to [build a secure etcd cluster][security].
 + Enable client cert authentication.
 + default: false
 + env variable: ETCD_CLIENT_CERT_AUTH
-+ CN authentication is not supported by gRPC-gateway.
++ CN authentication is not supported by gRPC-gateway. It's recommended to enable client cert authentication to prevent attacks from unauthenticated clients (e.g. CVE-2023-44487), especially when running etcd as a public service.
 
 ### --client-crl-file
 + Path to the client certificate revocation list file.
@@ -320,6 +320,7 @@ The security flags help to [build a secure etcd cluster][security].
 + Enable peer client cert authentication.
 + default: false
 + env variable: ETCD_PEER_CLIENT_CERT_AUTH
++ It's recommended to enable peer client cert authentication to prevent attacks from unauthenticated forged peers (e.g. CVE-2023-44487).
 
 ### --peer-crl-file
 + Path to the peer certificate revocation list file.

--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -134,6 +134,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Path to the client server TLS key file.
 --client-cert-auth 'false'
   Enable client cert authentication.
+  It's recommended to enable client cert authentication to prevent attacks from unauthenticated clients (e.g. CVE-2023-44487), especially when running etcd as a public service.
 --client-crl-file ''
   Path to the client certificate revocation list file.
 --client-cert-allowed-hostname ''
@@ -149,6 +150,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Path to the peer server TLS key file.
 --peer-client-cert-auth 'false'
   Enable peer client cert authentication.
+  It's recommended to enable peer client cert authentication to prevent attacks from unauthenticated forged peers (e.g. CVE-2023-44487).
 --peer-trusted-ca-file ''
   Path to the peer server TLS trusted CA file.
 --peer-cert-allowed-cn ''

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -134,6 +134,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Path to the client server TLS key file.
 --client-cert-auth 'false'
   Enable client cert authentication.
+  It's recommended to enable client cert authentication to prevent attacks from unauthenticated clients (e.g. CVE-2023-44487), especially when running etcd as a public service.
 --client-crl-file ''
   Path to the client certificate revocation list file.
 --client-cert-allowed-hostname ''
@@ -149,6 +150,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Path to the peer server TLS key file.
 --peer-client-cert-auth 'false'
   Enable peer client cert authentication.
+  It's recommended to enable peer client cert authentication to prevent attacks from unauthenticated forged peers (e.g. CVE-2023-44487).
 --peer-trusted-ca-file ''
   Path to the peer server TLS trusted CA file.
 --peer-cert-allowed-cn ''


### PR DESCRIPTION
See discussion in https://github.com/etcd-io/etcd/issues/16740

cc @enj @tjungblu @chaochn47 @fuweid @serathius 