### PR TITLE
Add missing documentation for distributed tracing sample rate

### DIFF
--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -219,6 +219,8 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Distributed tracing service name, must be same across all etcd instances.
 --experimental-distributed-tracing-instance-id ''
   Distributed tracing instance ID, must be unique per each etcd instance.
+--experimental-distributed-tracing-sampling-rate '0'
+  Number of samples to collect per million spans for OpenTelemetry Tracing (if enabled with experimental-enable-distributed-tracing flag).
 ```
 ### v2 Proxy
 

--- a/content/en/docs/v3.5/op-guide/monitoring.md
+++ b/content/en/docs/v3.5/op-guide/monitoring.md
@@ -139,7 +139,9 @@ In v3.5 etcd has added support for distributed tracing using [OpenTelemetry](htt
 This feature is still experimental and can change at any time.
 {{% /alert %}}
 
-To enable this experimental feature, pass the `--experimental-enable-distributed-tracing=true` to the etcd server. Setup and configure the distributed tracing by starting etcd server with the following optional flags:
+To enable this experimental feature, pass the `--experimental-enable-distributed-tracing=true` to the etcd server, along with the `--experimental-distributed-tracing-sampling-rate=<number>` flag to choose how many samples to collect per million spans, the default sampling rate is `0`.
+
+Configure the distributed tracing by starting etcd server with the following optional flags:
 
 - `--experimental-distributed-tracing-address` - (Optional) - "localhost:4317" - Address of the tracing collector.
 

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -219,6 +219,8 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Distributed tracing service name, must be same across all etcd instances.
 --experimental-distributed-tracing-instance-id ''
   Distributed tracing instance ID, must be unique per each etcd instance.
+--experimental-distributed-tracing-sampling-rate '0'
+  Number of samples to collect per million spans for OpenTelemetry Tracing (if enabled with experimental-enable-distributed-tracing flag).
 ```
 ### v2 Proxy
 

--- a/content/en/docs/v3.6/op-guide/monitoring.md
+++ b/content/en/docs/v3.6/op-guide/monitoring.md
@@ -139,7 +139,9 @@ In v3.5 etcd has added support for distributed tracing using [OpenTelemetry](htt
 This feature is still experimental and can change at any time.
 {{% /alert %}}
 
-To enable this experimental feature, pass the `--experimental-enable-distributed-tracing=true` to the etcd server. Setup and configure the distributed tracing by starting etcd server with the following optional flags:
+To enable this experimental feature, pass the `--experimental-enable-distributed-tracing=true` to the etcd server, along with the `--experimental-distributed-tracing-sampling-rate=<number>` flag to choose how many samples to collect per million spans, the default sampling rate is `0`.
+
+Configure the distributed tracing by starting etcd server with the following optional flags:
 
 - `--experimental-distributed-tracing-address` - (Optional) - "localhost:4317" - Address of the tracing collector.
 


### PR DESCRIPTION
This pull requests updates our v3.5 and v3.6 op-guide `monitoring.md` and `configuration.md` to ensure the distributed tracing `--experimental-distributed-tracing-sampling-rate` is documented.

Follow-on from https://github.com/etcd-io/etcd/pull/16951.

Part of https://github.com/etcd-io/etcd/issues/16935.