### PR TITLE
fix: :bug: `etcdctl` for `snapshot status` is deprecated

### DIFF
--- a/content/en/docs/v3.5/op-guide/maintenance.md
+++ b/content/en/docs/v3.5/op-guide/maintenance.md
@@ -165,7 +165,7 @@ A snapshot is taken with `etcdctl`:
 
 ```sh
 $ etcdctl snapshot save backup.db
-$ etcdctl --write-out=table snapshot status backup.db
+$ etcdutl --write-out=table snapshot status backup.db
 +----------+----------+------------+------------+
 |   HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |
 +----------+----------+------------+------------+

--- a/content/en/docs/v3.5/tutorials/how-to-save-database.md
+++ b/content/en/docs/v3.5/tutorials/how-to-save-database.md
@@ -19,7 +19,7 @@ Snapshot saved at my.db
 ```
 
 ```shell
-etcdctl --write-out=table --endpoints=$ENDPOINTS snapshot status my.db
+etcdutl --write-out=table snapshot status my.db
 
 +---------+----------+------------+------------+
 |  HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |

--- a/content/en/docs/v3.6/op-guide/maintenance.md
+++ b/content/en/docs/v3.6/op-guide/maintenance.md
@@ -165,7 +165,7 @@ A snapshot is taken with `etcdctl`:
 
 ```sh
 $ etcdctl snapshot save backup.db
-$ etcdctl --write-out=table snapshot status backup.db
+$ etcdutl --write-out=table snapshot status backup.db
 +----------+----------+------------+------------+
 |   HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |
 +----------+----------+------------+------------+

--- a/content/en/docs/v3.6/tutorials/how-to-save-database.md
+++ b/content/en/docs/v3.6/tutorials/how-to-save-database.md
@@ -19,7 +19,7 @@ Snapshot saved at my.db
 ```
 
 ```shell
-etcdctl --write-out=table --endpoints=$ENDPOINTS snapshot status my.db
+etcdutl --write-out=table snapshot status my.db
 
 +---------+----------+------------+------------+
 |  HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |


### PR DESCRIPTION
The `etcdctl`  for `snapshot status` is deprecated and we should use `etcdutl` instead.
Signed-off-by: mehdiMj <mehdi.is@live.com>