### PR TITLE
Fix the location of the Node.js LTS download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Follow these steps to add documentation for a newly released version of etcd, vX
 [etcd.io]: https://etcd.io
 [Hugo]: https://gohugo.io
 [localhost:8888]: http://localhost:8888
-[LTS release]: https://nodejs.org/en/about/releases/
+[LTS release]: https://nodejs.org/en/download/
 [Netlify]: https://netlify.com
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating


### PR DESCRIPTION
This is a minor fix to the README, as I was working on another PR. While setting up my local environment, I noticed that the Node.js LTS link was broken.