### PR TITLE
Introduce dependabot to stay on top of npm ecosystem security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # We can't bump hugo-extended further than 0.110.0.
+      # Refer: https://github.com/etcd-io/website/issues/717
+      - dependency-name: "hugo-extended"


### PR DESCRIPTION
Currently security patching for the etcd website npm dependencies relies on a maintainer remembering to review the contents of `package.json` and manually check for updates running something like `npm audit`.

As a result most of the time it just doesn't happen and vulnerabilities go unpatched for long periods of time.

We can automate staying on top of these by adding ` dependabot.yml` so we can more proactively know when updates are required. There are not a large number of dependencies so it should not be too noisy.

Note: I've ignored `hugo-extended` as we know that is blocked until docsy upgrade is done.