### PR TITLE
Update build from source instructions

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -2,7 +2,7 @@
 title: v3.4 docs
 cascade:
   version: &vers v3.4
-  git_version_tag: v3.4.16
+  git_version_tag: v3.4.28
   is_deprecated: true
   exclude_search: true
 linkTitle: *vers

--- a/content/en/docs/v3.4/install.md
+++ b/content/en/docs/v3.4/install.md
@@ -2,7 +2,7 @@
 title: Install
 weight: 1150
 description: Instructions for installing etcd from pre-built binaries or from source.
-minGoVers: 1.13
+minGoVers: 1.20
 ---
 
 ## Requirements

--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -3,7 +3,7 @@ title: v3.5 docs
 cascade:
   version: v3.5
   versName: &name v3.5
-  git_version_tag: v3.5.0
+  git_version_tag: v3.5.11
   exclude_search: false
 linkTitle: *name
 simple_list: true

--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -2,7 +2,7 @@
 title: Install
 weight: 1150
 description: Instructions for installing etcd from pre-built binaries or from source.
-minGoVers: 1.16
+minGoVers: 1.20
 ---
 
 ## Requirements

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -2,7 +2,7 @@
 title: Install
 weight: 1150
 description: Instructions for installing etcd from pre-built binaries or from source.
-minGoVers: 1.16
+minGoVers: 1.21
 ---
 
 ## Requirements


### PR DESCRIPTION
Our instructions for building etcd from source on the website (example https://etcd.io/docs/v3.5/install/#build-from-source) are currently out of date.

This pull request ensures the correct golang version pre-requisites are listed and that a modern tag of etcd will be cloned to avoid user footguns.