### PR TITLE
Render-link: trim whitespace from end template

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -5,3 +5,4 @@
 >
 {{- .Text | safeHTML -}}
 </a>
+{{- /* This directive ensures that all trailing whitespace is trimmed. */ -}}


### PR DESCRIPTION
Fixes #486 