### PR TITLE
Update website installation instructions to latest release tags

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -2,7 +2,7 @@
 title: v3.4 docs
 cascade:
   version: &vers v3.4
-  git_version_tag: v3.4.28
+  git_version_tag: v3.4.30
   is_deprecated: true
   exclude_search: true
 linkTitle: *vers

--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -3,7 +3,7 @@ title: v3.5 docs
 cascade:
   version: v3.5
   versName: &name v3.5
-  git_version_tag: v3.5.11
+  git_version_tag: v3.5.12
   exclude_search: false
 linkTitle: *name
 simple_list: true


### PR DESCRIPTION
Update the v3.5 release from v3.5.11 to v3.5.12. While working on #774, I noticed it was outdated.