### PR TITLE
correct default config

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -98,11 +98,6 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
 + default: 0
 + env variable: ETCD_BACKEND_BATCH_LIMIT
 
-### --backend-bbolt-freelist-type
-+ The freelist type that etcd backend(bboltdb) uses (array and map are supported types).
-+ default: map
-+ env variable: ETCD_BACKEND_BBOLT_FREELIST_TYPE
-
 ### --backend-batch-interval
 + BackendBatchInterval is the maximum time before commit the backend transaction.
 + default: 0
@@ -457,6 +452,11 @@ Follow the instructions when using these flags.
 + env variable: (not supported)
 
 ## Experimental flags
+
+### --experimental-backend-bbolt-freelist-type
++ The freelist type that etcd backend(bboltdb) uses (array and map are supported types).
++ default: array
++ env variable: ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE
 
 ### --experimental-corrupt-check-time
 + Duration of time between cluster corruption check passes


### PR DESCRIPTION
correct default config val of `--backend-bbolt-freelist-type` for v3.4
see  #378