### PR TITLE
feat: add EL install instructions

### DIFF
--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -96,7 +96,12 @@ $ etcd --version
 ### Enterprise Linux (CentOS Stream, RHEL)
 
 - Prerequisites
-   - Enable a [RDO repository](https://www.rdoproject.org/what/repos/) or a [OpenStack repository from extras](https://docs.openstack.org/install-guide/environment-packages-rdo.html#enable-the-openstack-repository)
+   - Enable a repository that ships etcd:
+      - [PostgreSQL YUM Repository](https://yum.postgresql.org/). Includes
+      up-to-date versions
+      - [RDO repository](https://www.rdoproject.org/what/repos/) or a
+      [OpenStack repository from extras](https://docs.openstack.org/install-guide/environment-packages-rdo.html#enable-the-openstack-repository).
+      Includes older versions for compatibility with the OpenStack release.
 
 - Procedure
    - Install using dnf

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -96,7 +96,12 @@ $ etcd --version
 ### Enterprise Linux (CentOS Stream, RHEL)
 
 - Prerequisites
-   - Enable a [RDO repository](https://www.rdoproject.org/what/repos/) or a [OpenStack repository from extras](https://docs.openstack.org/install-guide/environment-packages-rdo.html#enable-the-openstack-repository)
+   - Enable a repository that ships etcd:
+      - [PostgreSQL YUM Repository](https://yum.postgresql.org/). Includes
+      up-to-date versions
+      - [RDO repository](https://www.rdoproject.org/what/repos/) or a
+      [OpenStack repository from extras](https://docs.openstack.org/install-guide/environment-packages-rdo.html#enable-the-openstack-repository).
+      Includes older versions for compatibility with the OpenStack release.
 
 - Procedure
    - Install using dnf


### PR DESCRIPTION
Adds install instructions for Enterprise Linux (CentOS Stream, RHEL) - repositories include stable etcd release for an OpenStack installation

Should be integrated with #774 