### PR TITLE
Update "How to access etcd" page: add prereq, add h2 header, issue 790

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -98,11 +98,6 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
 + default: 0
 + env variable: ETCD_BACKEND_BATCH_LIMIT
 
-### --backend-bbolt-freelist-type
-+ The freelist type that etcd backend(bboltdb) uses (array and map are supported types).
-+ default: map
-+ env variable: ETCD_BACKEND_BBOLT_FREELIST_TYPE
-
 ### --backend-batch-interval
 + BackendBatchInterval is the maximum time before commit the backend transaction.
 + default: 0
@@ -457,6 +452,11 @@ Follow the instructions when using these flags.
 + env variable: (not supported)
 
 ## Experimental flags
+
+### --experimental-backend-bbolt-freelist-type
++ The freelist type that etcd backend(bboltdb) uses (array and map are supported types).
++ default: array
++ env variable: ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE
 
 ### --experimental-corrupt-check-time
 + Duration of time between cluster corruption check passes

--- a/content/en/docs/v3.5/tutorials/how-to-access-etcd.md
+++ b/content/en/docs/v3.5/tutorials/how-to-access-etcd.md
@@ -7,15 +7,42 @@ weight: 200
 
 ![02_etcdctl_access_etcd_2016051001](https://storage.googleapis.com/etcd/demo/02_etcdctl_access_etcd_2016051001.gif)
 
-`put` command to write:
+## Prerequisites
+
+- [etcdctl](/docs/v3.5/dev-guide/interacting_v3/) is required
+
+## Write to an etcd cluster
+
+The `put` command is used to write to etcd in the format `etcdctl --endpoints=<endpoints> put <key> <value> [OPTIONS]`.
 
 ```shell
 etcdctl --endpoints=$ENDPOINTS put foo "Hello World!"
 ```
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- foo = <key>
+- "Hello World" = <value>
 
-`get` to read from etcd:
+## Read from an etcd cluster
+
+The `get` command is used to read from etcd in the format `etcdctl --endpoints=<endpoints> get <key>`.
 
 ```shell
 etcdctl --endpoints=$ENDPOINTS get foo
+```
+
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- foo = <key>
+
+All commands can accept an output format by setting `-w` or `--write-out` with an output format: `simple`, `json`, `protobuf`, or `fields`.
+The output format is used in the following format `etcdctl --endpoints=<endpoints> --write-out=<format>`.
+
+```shell
 etcdctl --endpoints=$ENDPOINTS --write-out="json" get foo
 ```
+
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- "json" = <format>
+- foo = <value>

--- a/content/en/docs/v3.6/tutorials/how-to-access-etcd.md
+++ b/content/en/docs/v3.6/tutorials/how-to-access-etcd.md
@@ -7,15 +7,42 @@ weight: 200
 
 ![02_etcdctl_access_etcd_2016051001](https://storage.googleapis.com/etcd/demo/02_etcdctl_access_etcd_2016051001.gif)
 
-`put` command to write:
+## Prerequisites
+
+- [etcdctl](/docs/v3.6/dev-guide/interacting_v3/) is required
+
+## Write to an etcd cluster
+
+The `put` command is used to write to etcd in the format `etcdctl --endpoints=<endpoints> put <key> <value> [OPTIONS]`.
 
 ```shell
 etcdctl --endpoints=$ENDPOINTS put foo "Hello World!"
 ```
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- foo = <key>
+- "Hello World" = <value>
 
-`get` to read from etcd:
+## Read from an etcd cluster
+
+The `get` command is used to read from etcd in the format `etcdctl --endpoints=<endpoints> get <key>`.
 
 ```shell
 etcdctl --endpoints=$ENDPOINTS get foo
+```
+
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- foo = <key>
+
+All commands can accept an output format by setting `-w` or `--write-out` with an output format: `simple`, `json`, `protobuf`, or `fields`.
+The output format is used in the following format `etcdctl --endpoints=<endpoints> --write-out=<format>`.
+
+```shell
 etcdctl --endpoints=$ENDPOINTS --write-out="json" get foo
 ```
+
+The variables in the above example are:
+- $ENDPOINTS = <endpoints>
+- "json" = <format>
+- foo = <value>


### PR DESCRIPTION
Fix issue: https://github.com/etcd-io/website/issues/790

This PR adds the following:
- Add prerequisites (etcdctl is required)
- Define all variables used in the examples in a bulleted list (in this case, $ENDPOINTS, foo and `"Hello world"

Add sub-sections (## H2 headings) for:
- Pre-requisites
- Write to an etcd cluster
- Read from an etcd cluster


