### PR TITLE
Refresh etcd website owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,13 +2,10 @@
 
 approvers:
   - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
-  - mitake          # Hitoshi Mitake <h.mitake@gmail.com>
+  - chalin          # Patrice Chalin <chalin@cncf.io>
+  - jberkus         # Josh Berkus <jberkus@redhat.com>
+  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
+  - nate-double-u   # Nate W. <natew@cncf.io>
   - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
-  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
   - spzala          # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
-  - jberkus         # Josh Berkus <jberkus@redhat.com>
-  - nate-double-u   # Nate W. <natew@cncf.io>
-  - chalin          # Patrice Chalin <chalin@cncf.io>
-reviewers:
-  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>


### PR DESCRIPTION
Update myself from reviewer to approver following https://github.com/kubernetes/org/pull/4838.

Also:
- Listed entries in alphabetic order.
- Remove emeritus maintainers @ptabor and @mitake.

cc @serathius, @wenjiaswe, @ahrtr 