### PR TITLE
Restructure recovery steps

### DIFF
--- a/content/en/docs/v3.5/op-guide/recovery.md
+++ b/content/en/docs/v3.5/op-guide/recovery.md
@@ -18,13 +18,86 @@ Recovering a cluster first needs a snapshot of the keyspace from an etcd member.
 $ ETCDCTL_API=3 etcdctl --endpoints $ENDPOINT snapshot save snapshot.db
 ```
 
+Note that taking the snapshot from the `member/snap/db` file might lose data that has not been written yet, but is included in the wal (write-ahead-log) folder.
+
+## Status of a snapshot
+
+To understand which revision and hash a given snapshot contains, you can use the `etcdutl snapshot status` command:
+
+```sh
+$ etcdutl snapshot status member/snap/db -wtable
++---------+----------+------------+------------+
+|  HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |
++---------+----------+------------+------------+
+| 7ef846e |   485261 |      11642 |      94 MB |
++---------+----------+------------+------------+
+```
+
 ## Restoring a cluster
+
+### Revision Difference
+
+When you are restoring a cluster, existing clients may perceive the revision going back by many hundreds or thousands. This is due to the fact that a given snapshot only contains the data lineage up until the point of when it was taken, whereas the current state might already be further ahead.
+
+This is particularly a problem when running Kubernetes using etcd, where controllers and operators may use so called `informers` which act as local caches and get notified on updates using watches. Restoring to an older revision may not correctly refresh the caches, causing unpredictable and inconsistent behavior in the controllers.
+
+When restoring from a snapshot in the context of either: known consumers of the watch API, local cached copies of etcd data or when using Kubernetes in general - it is highly recommended to restore using "revision bumps" below. 
+
+### Restoring from snapshot
 
 To restore a cluster, all that is needed is a single snapshot "db" file. A cluster restore with `etcdutl snapshot restore` creates new etcd data directories; all members should restore using the same snapshot. Restoring overwrites some snapshot metadata (specifically, the member ID and cluster ID); the member loses its former identity. This metadata overwrite prevents the new member from inadvertently joining an existing cluster. Therefore in order to start a cluster from a snapshot, the restore must start a new logical cluster.
 
+A simple restore can be excuted like this:
+
+```sh
+$ etcdutl snapshot restore snapshot.db --data-dir output-dir
+```
+
+### Integrity Checks
+
 Snapshot integrity may be optionally verified at restore time. If the snapshot is taken with `etcdctl snapshot save`, it will have an integrity hash that is checked by `etcdutl snapshot restore`. If the snapshot is copied from the data directory, there is no integrity hash and it will only restore by using `--skip-hash-check`.
 
-A restore initializes a new member of a new cluster, with a fresh cluster configuration using `etcd`'s cluster configuration flags, but preserves the contents of the etcd keyspace. Continuing from the previous example, the following creates new etcd data directories (`m1.etcd`, `m2.etcd`, `m3.etcd`) for a three member cluster:
+
+### Restoring with revision bump
+
+In order to ensure the revisions are never decreasing after a restore, you can supply the `--bump-revision` option. This option takes a 64 bit integer, which denotes how many revisions to add to the current revision of the snapshot. Since each write to etcd increases the revision by one, you may cover a week old snapshot with bumping by 1'000'000'000 assuming that etcd runs with less than 1500 writes per second. 
+
+In the context of Kubernetes controllers, it is important to also mark all the revisions, including the bump, as compacted using `--mark-compacted`. This ensures that all watches are terminated and etcd does not respond to requests about revisions that happened after taking the snapshot - effectively invalidating its informer caches. 
+
+A full invocation may look like this:
+
+```sh
+$ etcdutl snapshot restore snapshot.db --bump-revision 1000000000 --mark-compacted --data-dir output-dir
+```
+
+### Restoring with updated membership
+
+The members of an etcd cluster are stored in etcd itself and maintained through the raft consensus algorithm. When quorum is lost entirely, you may want to reconsider where and how the new cluster is formed, for example, on an entirely new set of members.
+
+When restoring from a snapshot, you can directly supply the new membership into the datastore as follows:
+
+```sh
+$ etcdutl snapshot restore snapshot.db \
+  --name m1 \
+  --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
+  --initial-cluster-token etcd-cluster-1 \
+  --initial-advertise-peer-urls http://host1:2380
+```
+
+This ensures that the newly constructed cluster only connects to the other restored members with the given token and not older members that might still be alive and try to connect.
+
+Alternatively, when starting up etcd, you can supply `--force-new-cluster` to overwrite cluster membership while keeping existing application data. Note that this is strongly discouraged because it will panic if other members from previous cluster are still alive. Make sure to save snapshots periodically.
+
+
+### End-2-End Example
+
+Grab a snapshot from a live cluster using:
+
+```sh
+$ etcdctl snapshot save snapshot.db
+```
+
+Continuing from the previous example, the following creates new etcd data directories (`m1.etcd`, `m2.etcd`, `m3.etcd`) for a three member cluster:
 
 ```sh
 $ etcdutl snapshot restore snapshot.db \
@@ -64,10 +137,4 @@ $ etcd \
   --listen-peer-urls http://host3:2380 &
 ```
 
-Now the restored etcd cluster should be available and serving the keyspace given by the snapshot.
-
-## Restoring a cluster from membership mis-reconfiguration with wrong URLs
-
-Previously, etcd panics on [membership mis-reconfiguration with wrong URLs](https://github.com/etcd-io/etcd/issues/9173) (v3.2.15 or later returns [error early in client-side](https://github.com/etcd-io/etcd/pull/9174) before etcd server panic).
-
-Recommended way is restore from [snapshot](#snapshotting-the-keyspace). `--force-new-cluster` can be used to overwrite cluster membership while keeping existing application data, but is strongly discouraged because it will panic if other members from previous cluster are still alive. Make sure to save snapshot periodically.
+Now the restored etcd cluster should be available and serving the keyspace from the snapshot.

--- a/content/en/docs/v3.6/op-guide/recovery.md
+++ b/content/en/docs/v3.6/op-guide/recovery.md
@@ -18,13 +18,86 @@ Recovering a cluster first needs a snapshot of the keyspace from an etcd member.
 $ ETCDCTL_API=3 etcdctl --endpoints $ENDPOINT snapshot save snapshot.db
 ```
 
+Note that taking the snapshot from the `member/snap/db` file might lose data that has not been written yet, but is included in the wal (write-ahead-log) folder.
+
+## Status of a snapshot
+
+To understand which revision and hash a given snapshot contains, you can use the `etcdutl snapshot status` command:
+
+```sh
+$ etcdutl snapshot status member/snap/db -wtable
++---------+----------+------------+------------+
+|  HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |
++---------+----------+------------+------------+
+| 7ef846e |   485261 |      11642 |      94 MB |
++---------+----------+------------+------------+
+```
+
 ## Restoring a cluster
+
+### Revision Difference
+
+When you are restoring a cluster, existing clients may perceive the revision going back by many hundreds or thousands. This is due to the fact that a given snapshot only contains the data lineage up until the point of when it was taken, whereas the current state might already be further ahead.
+
+This is particularly a problem when running Kubernetes using etcd, where controllers and operators may use so called `informers` which act as local caches and get notified on updates using watches. Restoring to an older revision may not correctly refresh the caches, causing unpredictable and inconsistent behavior in the controllers.
+
+When restoring from a snapshot in the context of either: known consumers of the watch API, local cached copies of etcd data or when using Kubernetes in general - it is highly recommended to restore using "revision bumps" below. 
+
+### Restoring from snapshot
 
 To restore a cluster, all that is needed is a single snapshot "db" file. A cluster restore with `etcdutl snapshot restore` creates new etcd data directories; all members should restore using the same snapshot. Restoring overwrites some snapshot metadata (specifically, the member ID and cluster ID); the member loses its former identity. This metadata overwrite prevents the new member from inadvertently joining an existing cluster. Therefore in order to start a cluster from a snapshot, the restore must start a new logical cluster.
 
+A simple restore can be excuted like this:
+
+```sh
+$ etcdutl snapshot restore snapshot.db --data-dir output-dir
+```
+
+### Integrity Checks
+
 Snapshot integrity may be optionally verified at restore time. If the snapshot is taken with `etcdctl snapshot save`, it will have an integrity hash that is checked by `etcdutl snapshot restore`. If the snapshot is copied from the data directory, there is no integrity hash and it will only restore by using `--skip-hash-check`.
 
-A restore initializes a new member of a new cluster, with a fresh cluster configuration using `etcd`'s cluster configuration flags, but preserves the contents of the etcd keyspace. Continuing from the previous example, the following creates new etcd data directories (`m1.etcd`, `m2.etcd`, `m3.etcd`) for a three member cluster:
+
+### Restoring with revision bump
+
+In order to ensure the revisions are never decreasing after a restore, you can supply the `--bump-revision` option. This option takes a 64 bit integer, which denotes how many revisions to add to the current revision of the snapshot. Since each write to etcd increases the revision by one, you may cover a week old snapshot with bumping by 1'000'000'000 assuming that etcd runs with less than 1500 writes per second. 
+
+In the context of Kubernetes controllers, it is important to also mark all the revisions, including the bump, as compacted using `--mark-compacted`. This ensures that all watches are terminated and etcd does not respond to requests about revisions that happened after taking the snapshot - effectively invalidating its informer caches. 
+
+A full invocation may look like this:
+
+```sh
+$ etcdutl snapshot restore snapshot.db --bump-revision 1000000000 --mark-compacted --data-dir output-dir
+```
+
+### Restoring with updated membership
+
+The members of an etcd cluster are stored in etcd itself and maintained through the raft consensus algorithm. When quorum is lost entirely, you may want to reconsider where and how the new cluster is formed, for example, on an entirely new set of members.
+
+When restoring from a snapshot, you can directly supply the new membership into the datastore as follows:
+
+```sh
+$ etcdutl snapshot restore snapshot.db \
+  --name m1 \
+  --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
+  --initial-cluster-token etcd-cluster-1 \
+  --initial-advertise-peer-urls http://host1:2380
+```
+
+This ensures that the newly constructed cluster only connects to the other restored members with the given token and not older members that might still be alive and try to connect.
+
+Alternatively, when starting up etcd, you can supply `--force-new-cluster` to overwrite cluster membership while keeping existing application data. Note that this is strongly discouraged because it will panic if other members from previous cluster are still alive. Make sure to save snapshots periodically.
+
+
+### End-2-End Example
+
+Grab a snapshot from a live cluster using:
+
+```sh
+$ etcdctl snapshot save snapshot.db
+```
+
+Continuing from the previous example, the following creates new etcd data directories (`m1.etcd`, `m2.etcd`, `m3.etcd`) for a three member cluster:
 
 ```sh
 $ etcdutl snapshot restore snapshot.db \
@@ -64,10 +137,4 @@ $ etcd \
   --listen-peer-urls http://host3:2380 &
 ```
 
-Now the restored etcd cluster should be available and serving the keyspace given by the snapshot.
-
-## Restoring a cluster from membership mis-reconfiguration with wrong URLs
-
-Previously, etcd panics on [membership mis-reconfiguration with wrong URLs](https://github.com/etcd-io/etcd/issues/9173) (v3.2.15 or later returns [error early in client-side](https://github.com/etcd-io/etcd/pull/9174) before etcd server panic).
-
-Recommended way is restore from [snapshot](#snapshotting-the-keyspace). `--force-new-cluster` can be used to overwrite cluster membership while keeping existing application data, but is strongly discouraged because it will panic if other members from previous cluster are still alive. Make sure to save snapshot periodically.
+Now the restored etcd cluster should be available and serving the keyspace from the snapshot.


### PR DESCRIPTION
Clarify different aspects of restoring from snapshots, add more descriptive headers and sections to the existing docs.

Note, I will also update this for the 3.5 once we're happy with the structure and content of the recovery doc.