### PR TITLE
Updating configuration docs in 3.4 op-guide

### DIFF
--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -210,7 +210,7 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
 + env variable: ETCD_ENABLE_V2
 
 ### --next-cluster-version-compatible
-+ Enable 3.4 to be compatible with next version 3.5, to allow 3.4 server to join 3.5 cluster and start on 3.5 schema.
++ Enable a 3.4 server to be compatible with version 3.5, allowing the 3.4 server to join a 3.5 cluster and start on 3.5 schema for cluster downgrade purposes.
 + default: false
 + env variable: ETCD_NEXT_CLUSTER_VERSION_COMPATIBLE
 

--- a/content/en/docs/v3.4/op-guide/configuration.md
+++ b/content/en/docs/v3.4/op-guide/configuration.md
@@ -209,6 +209,11 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
 + default: false
 + env variable: ETCD_ENABLE_V2
 
+### --next-cluster-version-compatible
++ Enable 3.4 to be compatible with next version 3.5, to allow 3.4 server to join 3.5 cluster and start on 3.5 schema.
++ default: false
++ env variable: ETCD_NEXT_CLUSTER_VERSION_COMPATIBLE
+
 ## Proxy flags
 
 `--proxy` prefix flags configures etcd to run in [proxy mode][proxy]. "proxy" supports v2 API only.


### PR DESCRIPTION
Adding documentation for `next-cluster-version-compatible` which was added in 3.4. 


fixes: https://github.com/etcd-io/etcd/issues/17671