### PR TITLE
Fix missing backslash in learning/persistent-storage-files.md

### DIFF
--- a/content/en/docs/v3.5/learning/persistent-storage-files.md
+++ b/content/en/docs/v3.5/learning/persistent-storage-files.md
@@ -483,7 +483,7 @@ cat default.etcd/member/snap/0000000000000002-0000000000049425.snap |
   protoc --decode=snappb.snapshot \
     server/etcdserver/api/snap/snappb/snap.proto \
     -I $(go list -f '{{.Dir}}' github.com/gogo/protobuf/proto)/.. \
-    -I .
+    -I . \
     -I $(go list -m -f '{{.Dir}}' github.com/gogo/protobuf)/protobuf
 ```
 

--- a/content/en/docs/v3.6/learning/persistent-storage-files.md
+++ b/content/en/docs/v3.6/learning/persistent-storage-files.md
@@ -483,7 +483,7 @@ cat default.etcd/member/snap/0000000000000002-0000000000049425.snap |
   protoc --decode=snappb.snapshot \
     server/etcdserver/api/snap/snappb/snap.proto \
     -I $(go list -f '{{.Dir}}' github.com/gogo/protobuf/proto)/.. \
-    -I .
+    -I . \
     -I $(go list -m -f '{{.Dir}}' github.com/gogo/protobuf)/protobuf
 ```
 


### PR DESCRIPTION
- Add missing backslash in persistent-storage-files in v3.5, v3.6 in protoc sections

Fixes: #826 