### PR TITLE
Update installation version to latest tag

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -2,7 +2,7 @@
 title: v3.4 docs
 cascade:
   version: &vers v3.4
-  git_version_tag: v3.4.30
+  git_version_tag: v3.4.32
   is_deprecated: true
   exclude_search: true
 linkTitle: *vers

--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -3,7 +3,7 @@ title: v3.5 docs
 cascade:
   version: v3.5
   versName: &name v3.5
-  git_version_tag: v3.5.12
+  git_version_tag: v3.5.13
   exclude_search: false
 linkTitle: *name
 simple_list: true


### PR DESCRIPTION
We've recently released `3.5.13` and `3.4.32`, let's ensure these tags are referenced on our install pages.