### PR TITLE
github/workflows: introduce action to update version tag

### DIFF
--- a/.github/workflows/update-release-version-template.yaml
+++ b/.github/workflows/update-release-version-template.yaml
@@ -1,0 +1,28 @@
+---
+name: Reusable Template to Update Release
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        type: string
+        required: true
+
+jobs:
+  update-release:
+    name: Update Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - id: latest-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo version="$(gh release list --repo etcd-io/etcd --json 'tagName' -q 'map(select(.tagName | test("^'"$(echo "${{ inputs.release }}." | sed s/\\./\\\./g)"'"))) | .[0].tagName')" >> "$GITHUB_OUTPUT"
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          make update-release-version LATEST_VERSION="${{ steps.latest-release.outputs.version }}"

--- a/.github/workflows/update-release-version.yaml
+++ b/.github/workflows/update-release-version.yaml
@@ -1,0 +1,19 @@
+---
+name: Update Latest Release Versions Nightly
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  schedule:
+    - cron: '25 9 * * *' # runs every day at 09:25 UTC
+  workflow_dispatch:
+
+jobs:
+  v3_4:
+    uses: ./.github/workflows/update-release-version-template.yaml
+    with:
+      release: v3.4
+  v3_5:
+    uses: ./.github/workflows/update-release-version-template.yaml
+    with:
+      release: v3.5

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,11 @@ get-link-checker:
 
 clean:
 	rm -rf $(HTMLTEST_DIR) public/* resources
+
+.PHONY: update-release-version
+update-release-version:
+ifndef LATEST_VERSION
+	@echo "LATEST_VERSION needs to be specified" && exit 1
+else
+	./scripts/update_release_version.sh "$(LATEST_VERSION)"
+endif

--- a/scripts/update_release_version.sh
+++ b/scripts/update_release_version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# This script updates the version of the release in the release file
+# Usage: ./update_release_version.sh <new_version>
+
+set -eo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <new_version>"
+  exit 1
+fi
+
+new_version="$1"
+release_minor=$(echo "$new_version" | cut -d. -f1-2)
+index_file=content/en/docs/"$release_minor"/_index.md
+git_remote="${GIT_REMOTE:-origin}"
+branch="release-${release_minor}-update-latest-release-to-${new_version}"
+current_branch=$(git symbolic-ref HEAD --short)
+
+if [ -z "$GITHUB_ACTOR" ]; then
+  git_author="$(git config user.name)"
+  git_email="$(git config user.email)"
+else
+  git_author="$GITHUB_ACTOR"
+  git_email="$GITHUB_ACTOR@users.noreply.github.com"
+fi
+
+# Check for prerequisites to run the script.
+if ! which gh >/dev/null; then
+  echo "gh needs to be installed for this script to work"
+  exit 1
+fi
+if ! gh auth status >/dev/null; then
+  echo "gh needs to be authenticated for this script to work"
+  exit 1
+fi
+if ! grep git_version_tag "$index_file" | grep -v -e "$new_version\$" >/dev/null; then
+  echo "nothing to do; file $index_file is already up to date with $new_version"
+  exit 0
+fi
+if git ls-remote --exit-code "$git_remote" --heads refs/heads/"$branch" >/dev/null; then
+  echo "nothing to do; branch $branch already exists"
+  exit 0
+fi
+
+# Switch to a new branch.
+git checkout -b "$branch"
+trap 'git checkout "$current_branch"' EXIT
+
+# Update the release version in the release file.
+sed -i 's/git_version_tag:\sv\([0-9]\+\.\)\{2\}[0-9]\+/git_version_tag: '"$new_version"'/' "$index_file"
+
+# Commit the changes, push and create a PR.
+git add "$index_file"
+git -c user.name="$git_author" -c user.email="$git_email" commit --file=- <<EOL
+[${release_minor}] Update installation version to latest tag (${new_version})
+
+Signed-off-by: ${git_author} <${git_email}>
+EOL
+git push "$git_remote" "$branch"
+gh pr create --fill --body "Automated update for ${release_minor}: ${new_version}"


### PR DESCRIPTION
Add a nightly job that gets the latest released etcd version for supported branches (v3.4, v3.5) and create a commit and a pull request to keep it up to date.

An example of how this action works: https://github.com/ivanvc/etcd-website/pull/2. Note that it is a fictional version I used to test (https://github.com/ivanvc/etcd/releases).

The caveat is that we must have enabled "Allow GitHub actions to create and approve pull requests". I'm not sure if that's enabled for the repository, as I don't have access to that. Refer to: https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#preventing-github-actions-from-creating-or-approving-pull-requests