### PR TITLE
Describe user roles

### DIFF
--- a/content/en/docs/v3.6/start_here.md
+++ b/content/en/docs/v3.6/start_here.md
@@ -1,0 +1,48 @@
+---
+title: Start here
+weight: 900
+description: User roles and Persona's
+---
+
+## Evaluator 
+A technical decision-maker or architect evaluating whether etcd is suitable for their product, project, or organization. 
+#### Use Cases
+-  Researching the features and capabilities of etcd compared to other distributed key-value stores.
+- Evaluating etcd's performance, scalability, and reliability for handling their organization's workload.
+- Assessing etcd's compatibility with existing infrastructure and tools.
+- Examining etcd's community support, documentation, and ecosystem for long-term viability.
+
+[Get Started](../tutorials)
+
+## Operator
+A system administrator or DevOps engineer responsible for setting up and maintaining a standalone production etcd service. 
+#### Use Cases
+- Installing etcd on servers or virtual machines according to best practices for production deployment.
+- Configuring etcd for high availability and fault tolerance to ensure continuous operation.
+- Monitoring etcd cluster health, performance metrics, and alerts for any issues.
+- Performing routine maintenance tasks such as backups, upgrades, and security patching.
+- Troubleshooting and resolving issues related to etcd cluster operation.
+
+[Get Started](../tutorials)
+
+## Kubernetes Admin 
+A Kubernetes administrator responsible for installing and maintaining a Kubernetes cluster that uses etcd as the backend storage.
+#### Use Cases
+- Integrating etcd as the backend storage for a new Kubernetes cluster deployment.
+- Upgrading etcd versions in an existing Kubernetes cluster while ensuring minimal downtime.
+- Scaling the etcd cluster to accommodate the growing demands of the Kubernetes cluster.
+- Monitoring etcd's performance and resource utilization within the Kubernetes environment.
+- Troubleshooting and debugging issues related to Kubernetes API server interactions with etcd.
+
+[Get Started](../tutorials)
+
+## Developer
+A software developer incorporating or integrating etcd into an application or service.
+#### Use Cases
+- Using etcd as a distributed configuration store to manage application settings and feature flags.
+- Implementing distributed locking and coordination using etcd's distributed consensus algorithms.
+- Integrating etcd into microservices architectures for service discovery and dynamic configuration updates.
+- Developing applications that leverage etcd's watch functionality to react to changes in key-value data.
+- Writing automated tests for applications that interact with etcd to ensure correctness and reliability.
+
+[Get Started](../tutorials)


### PR DESCRIPTION
This PR pertains to issue #780  and also the umbrella issue #766 

Working on describing the 4 user roles defined in the initial analysis and implementation plan for the `etcd` doc updates. 

To note:  the initial implementation plan requests a link to each user workflow / tasks for each user group (#765). 

These are currently been developed and improved at the moment, for now they direct to the original `tutorials` page. 
 
Any suggestions / feedback welcome as always.
