### PR TITLE
Bump netlify-cli to resolve cve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    allow:
+        dependency-type: "development"
+        dependency-type: "production"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autoprefixer": "^10.4.18",
     "docsy": "github:google/docsy#semver:0.10.0",
     "hugo-extended": "^0.127.0",
-    "netlify-cli": "^17.15.2",
+    "netlify-cli": "^17.29.0",
     "postcss": "^8.4.31",
     "postcss-cli": "^11.0.0"
   }


### PR DESCRIPTION
Refer: https://github.com/advisories/GHSA-grv7-fg5c-xmjg

I was expecting dependabot to raise this automatically. Wondering if it hasn't because it's only a dev dependency, updated dependabot config to explicitly include both production and development dependencies.