### PR TITLE
Fix dependabot config to ensure allow is an array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
     schedule:
       interval: weekly
     allow:
-        dependency-type: "development"
-        dependency-type: "production"
+      - dependency-type: "development"
+      - dependency-type: "production"


### PR DESCRIPTION
My last pr didn't quite get the dependabot config right, `allow` is supposed to be an array, refer: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow