### PR TITLE
Improvements to the GitHub update release version workflow

### DIFF
--- a/scripts/update_release_version.sh
+++ b/scripts/update_release_version.sh
@@ -55,6 +55,8 @@ git add "${index_file}"
 git -c user.name="${git_author}" -c user.email="${git_email}" commit --file=- <<EOL
 [${release_minor}] Update installation version to latest tag (${new_version})
 
+cc. @etcd-io/maintainers-website
+
 Signed-off-by: ${git_author} <${git_email}>
 EOL
 git push "${git_remote}" "${branch}"

--- a/scripts/update_release_version.sh
+++ b/scripts/update_release_version.sh
@@ -10,18 +10,18 @@ if [ "$#" -ne 1 ]; then
 fi
 
 new_version="$1"
-release_minor=$(echo "$new_version" | cut -d. -f1-2)
-index_file=content/en/docs/"$release_minor"/_index.md
+release_minor=$(echo "${new_version}" | cut -d. -f1-2)
+index_file=content/en/docs/"${release_minor}"/_index.md
 git_remote="${GIT_REMOTE:-origin}"
 branch="release-${release_minor}-update-latest-release-to-${new_version}"
 current_branch=$(git symbolic-ref HEAD --short)
 
-if [ -z "$GITHUB_ACTOR" ]; then
+if [ -z "${GITHUB_ACTOR}" ]; then
   git_author="$(git config user.name)"
   git_email="$(git config user.email)"
 else
-  git_author="$GITHUB_ACTOR"
-  git_email="$GITHUB_ACTOR@users.noreply.github.com"
+  git_author="${GITHUB_ACTOR}"
+  git_email="${GITHUB_ACTOR}@users.noreply.github.com"
 fi
 
 # Check for prerequisites to run the script.
@@ -33,30 +33,30 @@ if ! gh auth status >/dev/null; then
   echo "gh needs to be authenticated for this script to work"
   exit 1
 fi
-if ! grep git_version_tag "$index_file" | grep -v -e "$new_version\$" >/dev/null; then
-  echo "nothing to do; file $index_file is already up to date with $new_version"
+if ! grep git_version_tag "${index_file}" | grep -v -e "${new_version}\$" >/dev/null; then
+  echo "nothing to do; file ${index_file} is already up to date with ${new_version}"
   exit 0
 fi
-if git ls-remote --exit-code "$git_remote" --heads refs/heads/"$branch" >/dev/null; then
-  echo "nothing to do; branch $branch already exists"
+if git ls-remote --exit-code "${git_remote}" --heads refs/heads/"${branch}" >/dev/null; then
+  echo "nothing to do; branch ${branch} already exists"
   exit 0
 fi
 
 # Switch to a new branch.
-git checkout -b "$branch"
-trap 'git checkout "$current_branch"' EXIT
+git checkout -b "${branch}"
+trap 'git checkout "${current_branch}"' EXIT
 
 # Update the release version in the release file.
-sed -i 's/git_version_tag:\sv\([0-9]\+\.\)\{2\}[0-9]\+/git_version_tag: '"$new_version"'/' "$index_file"
+sed -i 's/git_version_tag:\sv\([0-9]\+\.\)\{2\}[0-9]\+/git_version_tag: '"${new_version}"'/' "${index_file}"
 
 # Commit the changes, push and create a PR.
-git add "$index_file"
-git -c user.name="$git_author" -c user.email="$git_email" commit --file=- <<EOL
+git add "${index_file}"
+git -c user.name="${git_author}" -c user.email="${git_email}" commit --file=- <<EOL
 [${release_minor}] Update installation version to latest tag (${new_version})
 
 Signed-off-by: ${git_author} <${git_email}>
 EOL
-git push "$git_remote" "$branch"
+git push "${git_remote}" "${branch}"
 
 if [ -n "${CREATE_PULL_REQUEST}" ]; then
   gh pr create --fill --body "Automated update for ${release_minor}: ${new_version}"

--- a/scripts/update_release_version.sh
+++ b/scripts/update_release_version.sh
@@ -16,12 +16,13 @@ git_remote="${GIT_REMOTE:-origin}"
 branch="release-${release_minor}-update-latest-release-to-${new_version}"
 current_branch=$(git symbolic-ref HEAD --short)
 
-if [ -z "${GITHUB_ACTOR}" ]; then
+if [ -z "${GITHUB_ACTIONS}" ]; then
   git_author="$(git config user.name)"
   git_email="$(git config user.email)"
 else
-  git_author="${GITHUB_ACTOR}"
-  git_email="${GITHUB_ACTOR}@users.noreply.github.com"
+  # Refer to https://github.com/orgs/community/discussions/26560#discussioncomment-3252340
+  git_author="github-actions[bot]"
+  git_email="41898282+github-actions[bot]@users.noreply.github.com"
 fi
 
 # Check for prerequisites to run the script.

--- a/scripts/update_release_version.sh
+++ b/scripts/update_release_version.sh
@@ -57,4 +57,7 @@ git -c user.name="$git_author" -c user.email="$git_email" commit --file=- <<EOL
 Signed-off-by: ${git_author} <${git_email}>
 EOL
 git push "$git_remote" "$branch"
-gh pr create --fill --body "Automated update for ${release_minor}: ${new_version}"
+
+if [ -n "${CREATE_PULL_REQUEST}" ]; then
+  gh pr create --fill --body "Automated update for ${release_minor}: ${new_version}"
+fi


### PR DESCRIPTION
Follow-up on #845, this pull request has the following improvements:

* Skips creating the automated pull request due to the limitation with permissions
* Uses `github-actions[bot]` as the commit author instead of impersonating the last actor
* Mentions `@etcd-io/website-maintainers` in the commit message