### PR TITLE
improving text for transactional write

### DIFF
--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -21,3 +21,28 @@ del user1
 failure requests (get, put, delete):
 put user1 good
 ```
+
+### Transaction for multiple writes
+
+A transaction is an atomic If/Then/Else construct over the key-value store. It provides a primitive for grouping requests together in atomic blocks (i.e., then/else) whose execution is guarded (i.e., if) based on the contents of the key-value store. Transactions can be used for protecting keys from unintended concurrent updates, building compare-and-swap operations, and developing higher-level concurrency control. However, modifications to the same key multiple times within a single transaction are forbidden.
+
+```shell
+etcdctl --endpoints=$ENDPOINTS put user1 bad
+
+etcdctl --endpoints=$ENDPOINTS txn --interactive
+compares:
+value("user1") = "bad"
+
+success requests (get, put, del):
+put user test
+put user2 testing3
+get user1
+
+failure requests (get, put, del):
+put user1 bad
+```
+
+<!--need to add gif showing the examples for multiple writes and failing when written to same key-->
+
+
+

--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -43,3 +43,4 @@ put user1 bad
 ```
 
 {{< figure src="/img/transaction-multiple-writes.gif" >}}
+

--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -43,4 +43,3 @@ put user1 bad
 ```
 
 {{< figure src="/img/transaction-multiple-writes.gif" >}}
-

--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -41,4 +41,5 @@ get user1
 failure requests (get, put, del):
 put user1 bad
 ```
+
 {{< figure src="/img/transaction-multiple-writes.gif" >}}

--- a/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.5/tutorials/how-to-transactional-write.md
@@ -41,8 +41,4 @@ get user1
 failure requests (get, put, del):
 put user1 bad
 ```
-
-<!--need to add gif showing the examples for multiple writes and failing when written to same key-->
-
-
-
+{{< figure src="/img/transaction-multiple-writes.gif" >}}

--- a/content/en/docs/v3.6/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.6/tutorials/how-to-transactional-write.md
@@ -43,4 +43,3 @@ put user1 bad
 ```
 
 {{< figure src="/img/transaction-multiple-writes.gif" >}}
-

--- a/content/en/docs/v3.6/tutorials/how-to-transactional-write.md
+++ b/content/en/docs/v3.6/tutorials/how-to-transactional-write.md
@@ -21,3 +21,26 @@ del user1
 failure requests (get, put, delete):
 put user1 good
 ```
+
+### Transaction for multiple writes
+
+A transaction is an atomic If/Then/Else construct over the key-value store. It provides a primitive for grouping requests together in atomic blocks (i.e., then/else) whose execution is guarded (i.e., if) based on the contents of the key-value store. Transactions can be used for protecting keys from unintended concurrent updates, building compare-and-swap operations, and developing higher-level concurrency control. However, modifications to the same key multiple times within a single transaction are forbidden.
+
+```shell
+etcdctl --endpoints=$ENDPOINTS put user1 bad
+
+etcdctl --endpoints=$ENDPOINTS txn --interactive
+compares:
+value("user1") = "bad"
+
+success requests (get, put, del):
+put user test
+put user2 testing3
+get user1
+
+failure requests (get, put, del):
+put user1 bad
+```
+
+{{< figure src="/img/transaction-multiple-writes.gif" >}}
+


### PR DESCRIPTION
Pertains to issue #901. Doesn't have the GIF/video example attached. The text added in this PR is picked from the API documentation and I felt its relevant here as well.