### PR TITLE
dependency: bump hugo-extended from 0.134.1 to 0.135.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,12 +41,13 @@ imaging:
 languages:
   en:
     title: etcd
-    description: >-
-      A distributed, reliable key-value store for the most critical data of a
-      distributed system
     languageName: English
     contentDir: content/en
     weight: 1
+    params:
+      description: >-
+        A distributed, reliable key-value store for the most critical data of a
+        distributed system
 
 markup:
   goldmark:

--- a/layouts/shortcodes/metrics-list.html
+++ b/layouts/shortcodes/metrics-list.html
@@ -1,4 +1,4 @@
-{{ $dir := printf "/content/%s/%s%s" .Page.File.Lang .Page.File.Dir "metrics" -}}
+{{ $dir := printf "/content/%s/%s%s" .Page.Language.Lang .Page.File.Dir "metrics" -}}
 {{ $regexp := .Get "regexp" | default "." -}}
 
 {{ $counter := 0 -}}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "docsy": "github:google/docsy#semver:0.10.0",
-    "hugo-extended": "^0.134.1",
+    "hugo-extended": "0.135.0",
     "netlify-cli": "^17.35.0",
     "postcss": "^8.4.45",
     "postcss-cli": "^11.0.0"


### PR DESCRIPTION
This PR supersedes #904. I realized that even though we approved it, `hugo-extended` 0.135.0 had a deprecation that broke building the site.

I also locked the version, as I mentioned in the comment https://github.com/etcd-io/website/pull/904#pullrequestreview-2338729153.

I addressed the deprecation in the same commit, but let me know if you want me to split it into two commits. However, I prefer keeping the repository functional with every commit.

/cc @jmhbnz @spzala 