### PR TITLE
[v3.5] Update installation version to latest tag (v3.5.17)

### DIFF
--- a/content/en/docs/v3.5/_index.md
+++ b/content/en/docs/v3.5/_index.md
@@ -3,7 +3,7 @@ title: v3.5 docs
 cascade:
   version: v3.5
   versName: &name v3.5
-  git_version_tag: v3.5.16
+  git_version_tag: v3.5.17
   exclude_search: false
 linkTitle: *name
 simple_list: true


### PR DESCRIPTION
Updating 3.5 references to point to v3.5.17.