### PR TITLE
Promote ivanvc to approver for etcd website

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,11 +3,10 @@
 approvers:
   - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
   - chalin          # Patrice Chalin <chalin@cncf.io>
+  - ivanvc          # Ivan Valdes <ivan@vald.es>
   - jberkus         # Josh Berkus <jberkus@redhat.com>
   - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
   - nate-double-u   # Nate W. <natew@cncf.io>
   - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
   - spzala          # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
-reviewers:
-  - ivanvc          # Ivan Valdes <ivan@vald.es>


### PR DESCRIPTION
Reviewing the last 12 months contribution data https://github.com/etcd-io/website/graphs/contributors?from=6%2F01%2F2024 @ivanvc has been our top contributor to the etcd.io website.

Their contributions have been high quality, helped reduce toil and improve the state of this repository, including key items such as:
- https://github.com/etcd-io/website/pull/879
- https://github.com/etcd-io/website/pull/845
- https://github.com/etcd-io/website/pull/872

Additionally they have helped discuss and review many of the proposed pr's for this repository since joining the project https://github.com/etcd-io/website/pulls?q=is%3Apr+comment-by%3A%40ivanvc+.

@ivanvc is already a reviewer for `etcd-io/etcd` and a trusted member of our release team so with this pull request I propose we recognise their efforts here by promoting them to an approver for `etcd-io/website`.

cc @etcd-io/maintainers-website 