### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "submodule:get": "git submodule update --init --recursive --depth 1",
     "submodule:update": "git submodule update --remote --recursive --depth 1"
   },
+  "//": "TODO: Remove mkdirp once docsy > 0.11.0",
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "docsy": "github:google/docsy#semver:0.11.0",
     "hugo-extended": "0.140.2",
-    "netlify-cli": "^17.35.0",
-    "postcss": "^8.4.45",
+    "mkdirp": "^3.0.1",
+    "netlify-cli": "^18.0.1",
+    "postcss": "^8.5.1",
     "postcss-cli": "^11.0.0"
   }
 }


### PR DESCRIPTION
Supercedes https://github.com/etcd-io/website/pull/944 which is failing netlify deploy due to a missing `mkdirp` dev dependecy.

Upstream when the next `google/docsy` release tag is created we should be able to remove the `mkdirp` dev dependency refer https://github.com/google/docsy/commit/97dadaa6f4cf99113bbcf979fbc7a24963af6131. However as it stands currently builds will fail without it.