### PR TITLE
Add layout for 3.6 upgrade guide

### DIFF
--- a/content/en/docs/v3.6/upgrades/upgrade_3_6.md
+++ b/content/en/docs/v3.6/upgrades/upgrade_3_6.md
@@ -1,0 +1,29 @@
+---
+title: Upgrade etcd from 3.5 to 3.6
+weight: 6650
+description: Processes, checklists, and notes on upgrading etcd from 3.5 to 3.6
+---
+
+**This upgrade guide is still a work in process.**
+
+Before [starting an upgrade](#upgrade-procedure), read through the rest of this guide to prepare.
+
+The layout of this page as follows (copied from v3.5):
+
+### Upgrade checklists
+
+#### Deprecations
+
+### Server upgrade checklists
+
+#### Upgrade requirements
+
+#### Preparation
+
+#### Mixed versions
+
+#### Limitations
+
+#### Downgrade
+
+### Upgrade procedure


### PR DESCRIPTION
This pull request adds a base page for the v3.6 upgrade guide. Because this page doesn't exist, we have been requiring to remove the link from release candidate releases, and it also breaks Siyuan's PR (#965).

This is intended just to be a reference for #963.

Part of: #926.