### PR TITLE
[v3.4] Update installation version to latest tag (v3.4.36)

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -2,7 +2,7 @@
 title: v3.4 docs
 cascade:
   version: &vers v3.4
-  git_version_tag: v3.4.35
+  git_version_tag: v3.4.36
   is_deprecated: false
   exclude_search: true
 linkTitle: *vers


### PR DESCRIPTION
Auto-bump from GitHub actions.