### PR TITLE
Disable markdownlint MD052 rule

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,2 +1,6 @@
 config:
   line-length: false # Allow lines longer than 80 characters.
+  # Disable MD052 - Reference links and images should use a label that is defined.
+  # It breaks when a Hugo parameter is in the linked URL. Refer to issue
+  # https://github.com/DavidAnson/markdownlint/issues/1619
+  MD052: false


### PR DESCRIPTION
It breaks when a Hugo parameter is in the linked URL. Refer to issue https://github.com/DavidAnson/markdownlint/issues/1619.

Before disabling the rule:

```
$ docker run -w /src -v $PWD:/src --rm -ti davidanson/markdownlint-cli2 content/en/docs/v3.6/quickstart.md
markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
Finding: content/en/docs/v3.6/quickstart.md
Linting: 1 file(s)
Summary: 7 error(s)
content/en/docs/v3.6/quickstart.md:11:5 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "install"] [Context: "[Install][]"]
content/en/docs/v3.6/quickstart.md:48:20 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "api"] [Context: "[API][]"]
content/en/docs/v3.6/quickstart.md:49:12 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "clustering"] [Context: "[multi-machine cluster][clustering]"]
content/en/docs/v3.6/quickstart.md:50:16 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "configure"] [Context: "[configure][]"]
content/en/docs/v3.6/quickstart.md:51:8 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "integrations"] [Context: "[language bindings and tools][integrations]"]
content/en/docs/v3.6/quickstart.md:52:14 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "security"] [Context: "[secure an etcd cluster][security]"]
content/en/docs/v3.6/quickstart.md:53:3 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "tuning"] [Context: "[Tune etcd][tuning]"]
```

After:

```
$ docker run -w /src -v $PWD:/src --rm -ti davidanson/markdownlint-cli2 content/en/docs/v3.6/quickstart.md
markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
Finding: content/en/docs/v3.6/quickstart.md
Linting: 1 file(s)
Summary: 0 error(s)
```

Reference: [#sig-etcd Slack thread](https://kubernetes.slack.com/archives/C3HD8ARJ5/p1748621653581469).

/cc @jberkus