### PR TITLE
Fix the issue of incorrect description of "operations." in the TxnModeWriteWithSharedBuffer function

### DIFF
--- a/content/en/docs/v3.6/feature-gates/index.md
+++ b/content/en/docs/v3.6/feature-gates/index.md
@@ -73,12 +73,12 @@ etcd.
 | Feature                          | Default | Stage | Details                                                                               |
 |----------------------------------|---------|-------|--------------------------------------------------------------------------------------|
 | CompactHashCheck                 | false   | Alpha |Enables to check data corruption before serving any client/peer traffic.                                                                              |
-| InitialCorruptCheck              | false   | Alpha |Enables leader to periodically check followers compaction hashes. operations.                                                                           |
+| InitialCorruptCheck              | false   | Alpha |Enables leader to periodically check followers compaction hashes.                                                                           |
 | LeaseCheckpoint                  | false   | Alpha |Enables leader to send regular checkpoints to other members to prevent reset of remaining TTL on leader change.                                              |
 | LeaseCheckpointPersist           | false   | Alpha |Enables persisting remainingTTL to prevent indefinite auto-renewal of long lived leases.                                                                         |
 | SetMemberLocalAddr               | false   | Alpha |Enables using the first specified and non-loopback local address from initial-advertise-peer-urls as the local address when communicating with a peer.      |
 | StopGRPCServiceOnDefrag          | false   | Alpha |Enables etcd gRPC service to stop serving client requests on defragmentation.                                                                      |
-| TxnModeWriteWithSharedBuffer     | true    | Beta  |Enables the write transaction to use a shared buffer in its readonly check                                                                               |
+| TxnModeWriteWithSharedBuffer     | true    | Beta  |Enables the write transaction to use a shared buffer in its readonly check operations.                                                                               |
 
 ## Using a feature
 


### PR DESCRIPTION
I am here https://etcd.io/docs/v3.6/feature-gates/ In the functional gating instructions for Alpha or Beta features, it was found that "InitialCorruptCheck" and "TxnModeWriteWithSharedBuffer" have not been fully modified, and the position of "operations." is also not quite correct. I have made necessary modifications to the document and placed it in the correct location.