### PR TITLE
[add] etcd-workbench link to tools

### DIFF
--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -25,6 +25,7 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcd-defrag](https://github.com/ahrtr/etcd-defrag) - An easier to use and smarter etcd defragmentation tool.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 ## Libraries
 


### PR DESCRIPTION
Add etcd-workbench link to the [integrations](https://etcd.io/docs/v3.5/integrations/) page. It is a free and powerful ui client that makes etcd management easier, with support for Windows and macOS app installations, as well as web and docker deployments.