### PR TITLE
Disable exclude_search in _index.md (3.6)

### DIFF
--- a/content/en/docs/v3.6/_index.md
+++ b/content/en/docs/v3.6/_index.md
@@ -4,7 +4,7 @@ cascade:
   version: v3.6
   versName: &name v3.6
   git_version_tag: v3.6.0
-  exclude_search: true
+  exclude_search: false
 linkTitle: *name
 simple_list: true
 weight: -360 # Weight for doc version vX.Y should be -XY0


### PR DESCRIPTION
This change follows on a https://github.com/etcd-io/website/pull/1018#discussion_r2127264306 @ivanvc made to disable exclude_search in _index.md .