### PR TITLE
Add etcd-workbench link to tools

### DIFF
--- a/content/en/docs/v3.2/integrations.md
+++ b/content/en/docs/v3.2/integrations.md
@@ -1,10 +1,14 @@
 ---
 title: Libraries and tools
+weight: 1300
+description: A listing of etcd tools and client libraries
 ---
+
+Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
 **Tools**
 
-- [etcdctl](https://github.com/etcd-io/etcd/tree/{{< param git_version_tag >}}/etcdctl) - A command line client for etcd
+- [etcdctl](https://github.com/etcd-io/etcd/tree/main/etcdctl) - A command line client for etcd
 - [etcd-backup](https://web.archive.org/web/20190113041300/https://github.com/fanhattan/etcd-backup) - A powerful command line utility for dumping/restoring etcd - Supports v2
 - [etcd-dump](https://npmjs.org/package/etcd-dump) - Command line utility for dumping/restoring etcd.
 - [etcd-fs](https://github.com/xetorthio/etcd-fs) - FUSE filesystem for etcd

--- a/content/en/docs/v3.2/integrations.md
+++ b/content/en/docs/v3.2/integrations.md
@@ -4,9 +4,9 @@ weight: 1300
 description: A listing of etcd tools and client libraries
 ---
 
-Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
+Note that third-party libraries and tools (not hosted on [etcd-io main repository](https://github.com/etcd-io)) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
-**Tools**
+## Tools
 
 - [etcdctl](https://github.com/etcd-io/etcd/tree/main/etcdctl) - A command line client for etcd
 - [etcd-backup](https://web.archive.org/web/20190113041300/https://github.com/fanhattan/etcd-backup) - A powerful command line utility for dumping/restoring etcd - Supports v2
@@ -23,14 +23,18 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcdloadtest](https://github.com/sinsharat/etcdloadtest) - A command line load test client for etcd version 3.0 and above.
 - [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
-**Go libraries**
+## Libraries
+
+The sections below list etcd client libraries by language.
+
+### Go
 
 - [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
 - [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.2/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 
-**Java libraries**
+### Java
 
 - [coreos/jetcd](https://github.com/coreos/jetcd) - Supports v3
 - [boonproject/etcd](https://github.com/boonproject/boon/blob/master/etcd/README.md) - Supports v2, Async/Sync and waits
@@ -40,12 +44,12 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [AdoHe/etcd4j](http://github.com/AdoHe/etcd4j) - Supports v2 (enhance for real production cluster)
 - [cdancy/etcd-rest](https://github.com/cdancy/etcd-rest) - Uses jclouds to provide a complete implementation of v2 API.
 
-**Scala libraries**
+### Scala
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
 - [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
 
-**Python libraries**
+### Python
 
 - [kragniz/python-etcd3](https://github.com/kragniz/python-etcd3) - Work in progress client for v3
 - [jplana/python-etcd](https://github.com/jplana/python-etcd) - Supports v2
@@ -55,93 +59,96 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [txaio-etcd](https://github.com/crossbario/txaio-etcd) - Asynchronous etcd v3-only client library for Twisted (today) and asyncio (future)
 - [dims/etcd3-gateway](https://github.com/dims/etcd3-gateway) - etcd v3 API library using the HTTP grpc gateway
 
-**Node libraries**
+### Node
 
 - [stianeikeland/node-etcd](https://github.com/stianeikeland/node-etcd) - Supports v2 (w Coffeescript)
 - [lavagetto/nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) - Supports v2
 - [deedubs/node-etcd-config](https://github.com/deedubs/node-etcd-config) - Supports v2
 
-**Ruby libraries**
+### Ruby
 
 - [iconara/etcd-rb](https://github.com/iconara/etcd-rb)
 - [jpfuentes2/etcd-ruby](https://github.com/jpfuentes2/etcd-ruby)
 - [ranjib/etcd-ruby](https://github.com/ranjib/etcd-ruby) - Supports v2
 - [davissp14/etcdv3-ruby](https://github.com/davissp14/etcdv3-ruby) - Supports v3
 
-**C libraries**
+### C
 
 - [apache/celix/etcdlib](https://github.com/apache/celix/tree/master/libs/etcdlib) - Supports v2
 - [jdarcy/etcd-api](https://github.com/jdarcy/etcd-api) - Supports v2
 - [shafreeck/cetcd](https://github.com/shafreeck/cetcd) - Supports v2
 
-**C++ libraries**
+### C++
+
 - [edwardcapriolo/etcdcpp](https://github.com/edwardcapriolo/etcdcpp) - Supports v2
 - [suryanathan/etcdcpp](https://github.com/suryanathan/etcdcpp) - Supports v2 (with waits)
 - [nokia/etcd-cpp-api](https://github.com/nokia/etcd-cpp-api) - Supports v2
 - [nokia/etcd-cpp-apiv3](https://github.com/nokia/etcd-cpp-apiv3) - Supports v3
 
-**Clojure libraries**
+### Clojure
 
 - [aterreno/etcd-clojure](https://github.com/aterreno/etcd-clojure)
 - [dwwoelfel/cetcd](https://github.com/dwwoelfel/cetcd) - Supports v2
 - [rthomas/clj-etcd](https://github.com/rthomas/clj-etcd) - Supports v2
 
-**Erlang libraries**
+### Erlang
 
 - [marshall-lee/etcd.erl](https://github.com/marshall-lee/etcd.erl)
 
-**.Net Libraries**
+### .NET
 
 - [wangjia184/etcdnet](https://github.com/wangjia184/etcdnet) - Supports v2
 - [drusellers/etcetera](https://github.com/drusellers/etcetera)
 
-**PHP Libraries**
+### PHP
 
 - [linkorb/etcd-php](https://github.com/linkorb/etcd-php)
 - [activecollab/etcd](https://github.com/activecollab/etcd)
 
-**Lua Libraries**
+### Lua
 
 - [iresty/lua-resty-etcd](https://github.com/iresty/lua-resty-etcd)
 
-**Haskell libraries**
+### Haskell
 
 - [wereHamster/etcd-hs](https://github.com/wereHamster/etcd-hs)
 
-**R libraries**
+### R
 
 - [ropensci/etseed](https://github.com/ropensci/etseed)
 
-**Nim libraries**
+### Nim
 
 - [etcd_client](https://github.com/FedericoCeratto/nim-etcd-client)
 
-**Tcl libraries**
+### Tcl
 
 - [efrecon/etcd-tcl](https://github.com/efrecon/etcd-tcl) - Supports v2, except wait.
 
-**Rust libraries**
+### Rust
 
 - [jimmycuadra/rust-etcd](https://github.com/jimmycuadra/rust-etcd) - Supports v2
 
-**Gradle Plugins**
+### Gradle
 
 - [gradle-etcd-rest-plugin](https://github.com/cdancy/gradle-etcd-rest-plugin) - Supports v2
 
-**Chef Integration**
+## Deployment tools
+
+### Chef Integrations
 
 - [coderanger/etcd-chef](https://github.com/coderanger/etcd-chef)
 
-**Chef Cookbook**
+### Chef cookbooks
 
 - [spheromak/etcd-cookbook](https://github.com/spheromak/etcd-cookbook)
 
-**BOSH Releases**
+### BOSH releases
 
 - [cloudfoundry-community/etcd-boshrelease](https://github.com/cloudfoundry-community/etcd-boshrelease)
 - [cloudfoundry/cf-release](https://github.com/cloudfoundry/cf-release/tree/master/jobs/etcd)
 
-**Projects using etcd**
+## Projects using etcd
 
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++
 - [binocarlos/yoda](https://github.com/binocarlos/yoda) - etcd + ZeroMQ

--- a/content/en/docs/v3.2/integrations.md
+++ b/content/en/docs/v3.2/integrations.md
@@ -17,6 +17,7 @@ title: Libraries and tools
 - [etcd-rest](https://web.archive.org/web/20190113041300/https://github.com/mickep76/etcdrest) - Create generic REST API in Go using etcd as a backend with validation using JSON schema
 - [etcdsh](https://web.archive.org/web/20190113041250/https://github.com/kamilhark/etcdsh) - A command line client with support of command history and tab completion. Supports v2
 - [etcdloadtest](https://github.com/sinsharat/etcdloadtest) - A command line load test client for etcd version 3.0 and above.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 **Go libraries**
 

--- a/content/en/docs/v3.3/integrations.md
+++ b/content/en/docs/v3.3/integrations.md
@@ -4,9 +4,9 @@ weight: 1300
 description: A listing of etcd tools and client libraries
 ---
 
-Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
+Note that third-party libraries and tools (not hosted on [etcd-io main repository](https://github.com/etcd-io)) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
-**Tools**
+## Tools
 
 - [etcdctl](https://github.com/etcd-io/etcd/tree/master/etcdctl) - A command line client for etcd
 - [etcd-backup](https://web.archive.org/web/20190113041300/https://github.com/fanhattan/etcd-backup) - A powerful command line utility for dumping/restoring etcd - Supports v2
@@ -24,14 +24,18 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [lucas](https://github.com/ringtail/lucas) - A web-based key-value viewer for kubernetes etcd3.0+ cluster.
 - [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
-**Go libraries**
+## Libraries
+
+The sections below list etcd client libraries by language.
+
+### Go
 
 - [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
 - [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.3/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 
-**Java libraries**
+### Java
 
 - [coreos/jetcd](https://github.com/etcd-io/jetcd) - Supports v3
 - [boonproject/etcd](https://github.com/boonproject/boon/blob/master/etcd/README.md) - Supports v2, Async/Sync and waits
@@ -41,17 +45,17 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [AdoHe/etcd4j](http://github.com/AdoHe/etcd4j) - Supports v2 (enhance for real production cluster)
 - [cdancy/etcd-rest](https://github.com/cdancy/etcd-rest) - Uses jclouds to provide a complete implementation of v2 API.
 
-**Scala libraries**
+### Scala
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
 - [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
 
-**Perl libraries**
+### Perl
 
 - [hexfusion/perl-net-etcd](https://github.com/hexfusion/perl-net-etcd) - Supports v3 grpc gateway HTTP API
 - [robn/p5-etcd](https://github.com/robn/p5-etcd) - Supports v2
 
-**Python libraries**
+### Python
 
 - [kragniz/python-etcd3](https://github.com/kragniz/python-etcd3) - Client for v3
 - [jplana/python-etcd](https://github.com/jplana/python-etcd) - Supports v2
@@ -63,92 +67,95 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [aioetcd3](https://github.com/gaopeiliang/aioetcd3) - (Python 3.6+) etcd v3 API for asyncio
 - [Revolution1/etcd3-py](https://github.com/Revolution1/etcd3-py) - (python2.7 and python3.5+) Python client for etcd v3, using gRPC-JSON-Gateway
 
-**Node libraries**
+### Node
 
 - [stianeikeland/node-etcd](https://github.com/stianeikeland/node-etcd) - Supports v2 (w Coffeescript)
 - [lavagetto/nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) - Supports v2
 - [deedubs/node-etcd-config](https://github.com/deedubs/node-etcd-config) - Supports v2
 
-**Ruby libraries**
+### Ruby
 
 - [iconara/etcd-rb](https://github.com/iconara/etcd-rb)
 - [jpfuentes2/etcd-ruby](https://github.com/jpfuentes2/etcd-ruby)
 - [ranjib/etcd-ruby](https://github.com/ranjib/etcd-ruby) - Supports v2
 - [davissp14/etcdv3-ruby](https://github.com/davissp14/etcdv3-ruby) - Supports v3
 
-**C libraries**
+### C
 
 - [apache/celix/etcdlib](https://github.com/apache/celix/tree/master/libs/etcdlib) - Supports v2
 - [jdarcy/etcd-api](https://github.com/jdarcy/etcd-api) - Supports v2
 - [shafreeck/cetcd](https://github.com/shafreeck/cetcd) - Supports v2
 
-**C++ libraries**
+### C++
+
 - [edwardcapriolo/etcdcpp](https://github.com/edwardcapriolo/etcdcpp) - Supports v2
 - [suryanathan/etcdcpp](https://github.com/suryanathan/etcdcpp) - Supports v2 (with waits)
 - [nokia/etcd-cpp-api](https://github.com/nokia/etcd-cpp-api) - Supports v2
 - [nokia/etcd-cpp-apiv3](https://github.com/nokia/etcd-cpp-apiv3) - Supports v3
 
-**Clojure libraries**
+### Clojure
 
 - [aterreno/etcd-clojure](https://github.com/aterreno/etcd-clojure)
 - [dwwoelfel/cetcd](https://github.com/dwwoelfel/cetcd) - Supports v2
 - [rthomas/clj-etcd](https://github.com/rthomas/clj-etcd) - Supports v2
 
-**Erlang libraries**
+### Erlang
 
 - [marshall-lee/etcd.erl](https://github.com/marshall-lee/etcd.erl) - Supports v2
 - [zhongwencool/eetcd](https://github.com/zhongwencool/eetcd) - Supports v3+ (GRPC only)
 
-**.Net Libraries**
+### .NET
 
 - [wangjia184/etcdnet](https://github.com/wangjia184/etcdnet) - Supports v2
 - [drusellers/etcetera](https://github.com/drusellers/etcetera)
 - [shubhamranjan/dotnet-etcd](https://github.com/shubhamranjan/dotnet-etcd) - Supports v3+ (GRPC only)
 
-**PHP Libraries**
+### PHP
 
 - [linkorb/etcd-php](https://github.com/linkorb/etcd-php)
 - [activecollab/etcd](https://github.com/activecollab/etcd)
 - [ouqiang/etcd-php](https://github.com/ouqiang/etcd-php) - Client for v3 gRPC gateway
 
-**Haskell libraries**
+### Haskell
 
 - [wereHamster/etcd-hs](https://github.com/wereHamster/etcd-hs)
 
-**R libraries**
+### R
 
 - [ropensci/etseed](https://github.com/ropensci/etseed)
 
-**Nim libraries**
+### Nim
 
 - [etcd_client](https://github.com/FedericoCeratto/nim-etcd-client)
 
-**Tcl libraries**
+### Tcl
 
 - [efrecon/etcd-tcl](https://github.com/efrecon/etcd-tcl) - Supports v2, except wait.
 
-**Rust libraries**
+### Rust
 
 - [jimmycuadra/rust-etcd](https://github.com/jimmycuadra/rust-etcd) - Supports v2
 
-**Gradle Plugins**
+### Gradle
 
 - [gradle-etcd-rest-plugin](https://github.com/cdancy/gradle-etcd-rest-plugin) - Supports v2
 
-**Chef Integration**
+## Deployment tools
+
+### Chef integrations
 
 - [coderanger/etcd-chef](https://github.com/coderanger/etcd-chef)
 
-**Chef Cookbook**
+### Chef cookbooks
 
 - [spheromak/etcd-cookbook](https://github.com/spheromak/etcd-cookbook)
 
-**BOSH Releases**
+### BOSH releases
 
 - [cloudfoundry-community/etcd-boshrelease](https://github.com/cloudfoundry-community/etcd-boshrelease)
 - [cloudfoundry/cf-release](https://github.com/cloudfoundry/cf-release/tree/master/jobs/etcd)
 
-**Projects using etcd**
+## Projects using etcd
 
 - [etcd Raft users](https://github.com/etcd-io/etcd/blob/v3.3.13/raft/README.md#notable-users) - projects using etcd's raft library implementation.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++

--- a/content/en/docs/v3.3/integrations.md
+++ b/content/en/docs/v3.3/integrations.md
@@ -1,7 +1,10 @@
 ---
 title: Libraries and tools
-weight: 2
+weight: 1300
+description: A listing of etcd tools and client libraries
 ---
+
+Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
 **Tools**
 

--- a/content/en/docs/v3.3/integrations.md
+++ b/content/en/docs/v3.3/integrations.md
@@ -19,6 +19,7 @@ weight: 2
 - [etcdsh](https://web.archive.org/web/20190113041250/https://github.com/kamilhark/etcdsh) - A command line client with support of command history and tab completion. Supports v2
 - [etcdloadtest](https://github.com/sinsharat/etcdloadtest) - A command line load test client for etcd version 3.0 and above.
 - [lucas](https://github.com/ringtail/lucas) - A web-based key-value viewer for kubernetes etcd3.0+ cluster.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 **Go libraries**
 

--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -24,6 +24,7 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcd-druid](https://github.com/gardener/etcd-druid) - A Kubernetes operator to deploy etcd clusters and manage day-2 operations.
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 **Go libraries**
 

--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -91,6 +91,7 @@ The sections below list etcd client libraries by language.
 - [shafreeck/cetcd](https://github.com/shafreeck/cetcd) - Supports v2
 
 ### C++
+
 - [edwardcapriolo/etcdcpp](https://github.com/edwardcapriolo/etcdcpp) - Supports v2
 - [suryanathan/etcdcpp](https://github.com/suryanathan/etcdcpp) - Supports v2 (with waits)
 - [nokia/etcd-cpp-api](https://github.com/nokia/etcd-cpp-api) - Supports v2
@@ -163,7 +164,7 @@ The sections below list etcd client libraries by language.
 - [cloudfoundry-community/etcd-boshrelease](https://github.com/cloudfoundry-community/etcd-boshrelease)
 - [cloudfoundry/cf-release](https://github.com/cloudfoundry/cf-release/tree/master/jobs/etcd)
 
-## Projects using etcd 
+## Projects using etcd
 
 - [etcd Raft users](https://github.com/etcd-io/etcd/tree/master/raft#notable-users) - projects using etcd's raft library implementation.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++

--- a/content/en/docs/v3.4/integrations.md
+++ b/content/en/docs/v3.4/integrations.md
@@ -4,9 +4,9 @@ weight: 1300
 description: A listing of etcd tools and client libraries
 ---
 
-Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
+Note that third-party libraries and tools (not hosted on [etcd-io main repository](https://github.com/etcd-io)) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
-**Tools**
+## Tools
 
 - [etcdctl](https://github.com/etcd-io/etcd/tree/master/etcdctl) - A command line client for etcd
 - [etcd-dump](https://npmjs.org/package/etcd-dump) - Command line utility for dumping/restoring etcd.
@@ -26,14 +26,18 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
 - [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
-**Go libraries**
+## Libraries
+
+The sections below list etcd client libraries by language.
+
+### Go
 
 - [etcd/client/v3](https://github.com/etcd-io/etcd/tree/main/client/v3) - the officially maintained Go client for v3
 - [etcd/client/v2](https://github.com/etcd-io/etcd/tree/release-3.4/client/) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
 - [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 
-**Java libraries**
+### Java
 
 - [coreos/jetcd](https://github.com/etcd-io/jetcd) - Supports v3
 - [boonproject/etcd](https://github.com/boonproject/boon/blob/master/etcd/README.md) - Supports v2, Async/Sync and waits
@@ -43,18 +47,18 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [AdoHe/etcd4j](http://github.com/AdoHe/etcd4j) - Supports v2 (enhance for real production cluster)
 - [cdancy/etcd-rest](https://github.com/cdancy/etcd-rest) - Uses jclouds to provide a complete implementation of v2 API.
 
-**Scala libraries**
+### Scala
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
 - [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
 - [mingchuno/etcd4s](https://github.com/mingchuno/etcd4s) - Supports v3 using gRPC with optional Akka Stream support.
 
-**Perl libraries**
+### Perl
 
 - [hexfusion/perl-net-etcd](https://github.com/hexfusion/perl-net-etcd) - Supports v3 grpc gateway HTTP API
 - [robn/p5-etcd](https://github.com/robn/p5-etcd) - Supports v2
 
-**Python libraries**
+### Python
 
 - [kragniz/python-etcd3](https://github.com/kragniz/python-etcd3) - Client for v3
 - [jplana/python-etcd](https://github.com/jplana/python-etcd) - Supports v2
@@ -66,39 +70,39 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [aioetcd3](https://github.com/gaopeiliang/aioetcd3) - (Python 3.6+) etcd v3 API for asyncio
 - [Revolution1/etcd3-py](https://github.com/Revolution1/etcd3-py) - (python2.7 and python3.5+) Python client for etcd v3, using gRPC-JSON-Gateway
 
-**Node libraries**
+### Node
 
 - [microsoft/etcd3](https://github.com/microsoft/etcd3) - Supports v3
 - [stianeikeland/node-etcd](https://github.com/stianeikeland/node-etcd) - Supports v2 (w Coffeescript)
 - [lavagetto/nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) - Supports v2
 - [deedubs/node-etcd-config](https://github.com/deedubs/node-etcd-config) - Supports v2
 
-**Ruby libraries**
+### Ruby
 
 - [iconara/etcd-rb](https://github.com/iconara/etcd-rb)
 - [jpfuentes2/etcd-ruby](https://github.com/jpfuentes2/etcd-ruby)
 - [ranjib/etcd-ruby](https://github.com/ranjib/etcd-ruby) - Supports v2
 - [davissp14/etcdv3-ruby](https://github.com/davissp14/etcdv3-ruby) - Supports v3
 
-**C libraries**
+### C
 
 - [apache/celix/etcdlib](https://github.com/apache/celix/tree/master/libs/etcdlib) - Supports v2
 - [jdarcy/etcd-api](https://github.com/jdarcy/etcd-api) - Supports v2
 - [shafreeck/cetcd](https://github.com/shafreeck/cetcd) - Supports v2
 
-**C++ libraries**
+### C++
 - [edwardcapriolo/etcdcpp](https://github.com/edwardcapriolo/etcdcpp) - Supports v2
 - [suryanathan/etcdcpp](https://github.com/suryanathan/etcdcpp) - Supports v2 (with waits)
 - [nokia/etcd-cpp-api](https://github.com/nokia/etcd-cpp-api) - Supports v2
 - [nokia/etcd-cpp-apiv3](https://github.com/nokia/etcd-cpp-apiv3) - Supports v3
 
-**Clojure libraries**
+### Clojure
 
 - [aterreno/etcd-clojure](https://github.com/aterreno/etcd-clojure)
 - [dwwoelfel/cetcd](https://github.com/dwwoelfel/cetcd) - Supports v2
 - [rthomas/clj-etcd](https://github.com/rthomas/clj-etcd) - Supports v2
 
-**Erlang libraries**
+### Erlang
 
 - [marshall-lee/etcd.erl](https://github.com/marshall-lee/etcd.erl) - Supports v2
 - [zhongwencool/eetcd](https://github.com/zhongwencool/eetcd) - Supports v3+ (GRPC only)
@@ -107,57 +111,60 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 
 - [team-telnyx/etcdex](https://github.com/team-telnyx/etcdex) - Supports v3+ (GRPC only)
 
-**.Net Libraries**
+### .NET
 
 - [wangjia184/etcdnet](https://github.com/wangjia184/etcdnet) - Supports v2
 - [drusellers/etcetera](https://github.com/drusellers/etcetera)
 - [shubhamranjan/dotnet-etcd](https://github.com/shubhamranjan/dotnet-etcd) - Supports v3+ (GRPC only)
 - [SimplifyNet/Etcd.Microsoft.Extensions.Configuration](https://github.com/SimplifyNet/Etcd.Microsoft.Extensions.Configuration)
 
-**PHP Libraries**
+### PHP
 
 - [linkorb/etcd-php](https://github.com/linkorb/etcd-php)
 - [activecollab/etcd](https://github.com/activecollab/etcd)
 - [ouqiang/etcd-php](https://github.com/ouqiang/etcd-php) - Client for v3 gRPC gateway
 
-**Haskell libraries**
+### Haskell
 
 - [wereHamster/etcd-hs](https://github.com/wereHamster/etcd-hs)
 
-**R libraries**
+### R
 
 - [ropensci/etseed](https://github.com/ropensci/etseed)
 
-**Nim libraries**
+### Nim
 
 - [etcd_client](https://github.com/FedericoCeratto/nim-etcd-client)
 
-**Tcl libraries**
+### Tcl
 
 - [efrecon/etcd-tcl](https://github.com/efrecon/etcd-tcl) - Supports v2, except wait.
 
-**Rust libraries**
+### Rust
 
 - [jimmycuadra/rust-etcd](https://github.com/jimmycuadra/rust-etcd) - Supports v2
 
-**Gradle Plugins**
+### Gradle
 
 - [gradle-etcd-rest-plugin](https://github.com/cdancy/gradle-etcd-rest-plugin) - Supports v2
 
-**Chef Integration**
+## Deployment tools
+
+### Chef integrations
 
 - [coderanger/etcd-chef](https://github.com/coderanger/etcd-chef)
 
-**Chef Cookbook**
+### Chef cookbooks
 
 - [spheromak/etcd-cookbook](https://github.com/spheromak/etcd-cookbook)
 
-**BOSH Releases**
+### BOSH releases
 
 - [cloudfoundry-community/etcd-boshrelease](https://github.com/cloudfoundry-community/etcd-boshrelease)
 - [cloudfoundry/cf-release](https://github.com/cloudfoundry/cf-release/tree/master/jobs/etcd)
 
-**Projects using etcd**
+## Projects using etcd 
+
 - [etcd Raft users](https://github.com/etcd-io/etcd/tree/master/raft#notable-users) - projects using etcd's raft library implementation.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++
 - [binocarlos/yoda](https://github.com/binocarlos/yoda) - etcd + ZeroMQ

--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -25,6 +25,7 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcd-defrag](https://github.com/ahrtr/etcd-defrag) - An easier to use and smarter etcd defragmentation tool.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 ## Libraries
 

--- a/content/en/docs/v3.5/integrations.md
+++ b/content/en/docs/v3.5/integrations.md
@@ -4,7 +4,7 @@ weight: 1300
 description: A listing of etcd tools and client libraries
 ---
 
-Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
+Note that third-party libraries and tools (not hosted on [etcd-io main repository](https://github.com/etcd-io)) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
 ## Tools
 

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -25,6 +25,7 @@ Note that third-party libraries and tools (not hosted on https://github.com/etcd
 - [etcdadm](https://github.com/kubernetes-sigs/etcdadm) - A command-line tool for operating an etcd cluster.
 - [etcd-defrag](https://github.com/ahrtr/etcd-defrag) - An easier to use and smarter etcd defragmentation tool.
 - [etcdhelper](https://github.com/tsonglew/intellij-etcdhelper) - An intellij platform plugin for etcd.
+- [etcd-workbench](https://github.com/tzfun/etcd-workbench) - A free and powerful ui client for etcd v3. Provides desktop application and web packages.
 
 ## Libraries
 

--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -4,7 +4,7 @@ weight: 1300
 description: A listing of etcd tools and client libraries
 ---
 
-Note that third-party libraries and tools (not hosted on https://github.com/etcd-io) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
+Note that third-party libraries and tools (not hosted on [etcd-io main repository](https://github.com/etcd-io)) mentioned below are not tested or maintained by the etcd team. Before using them, users are recommended to read and investigate them.
 
 ## Tools
 


### PR DESCRIPTION
Add etcd-workbench link to the integrations page. Hope this helps more developers.

It is a free and powerful ui client that makes etcd management easier, with support for Windows and macOS app installations, as well as web and docker deployments.