### PR TITLE
Remove bitnami chart reference from docs

### DIFF
--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -145,5 +145,4 @@ For a slightly more involved sanity check of your installation, see
 [releases]: https://github.com/etcd-io/etcd/releases/
 [tagged-release]: https://github.com/etcd-io/etcd/releases/tag/{{< param git_version_tag >}}
 [Supported platforms]: {{< relref "op-guide/supported-platform" >}}
-[Bitnami's etcd Helm chart]: https://bitnami.com/stack/etcd/helm
 [Homebrew can run on Linux]: <https://docs.brew.sh/Homebrew-on-Linux>

--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -128,10 +128,6 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 - [Running etcd as a Kubernetes StatefulSet][]
 
-## Installation on Kubernetes, using a statefulset or helm chart
-
-The etcd project does not currently maintain an official helm chart.
-
 ## Installation check
 
 For a slightly more involved sanity check of your installation, see

--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -130,7 +130,7 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 ## Installation on Kubernetes, using a statefulset or helm chart
 
-The etcd project does not currently maintain a helm chart, however you can follow the instructions provided by [Bitnami's etcd Helm chart].
+The etcd project does not currently maintain an official helm chart.
 
 ## Installation check
 

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -145,5 +145,4 @@ For a slightly more involved sanity check of your installation, see
 [releases]: https://github.com/etcd-io/etcd/releases/
 [tagged-release]: https://github.com/etcd-io/etcd/releases/tag/{{< param git_version_tag >}}
 [Supported platforms]: {{< relref "op-guide/supported-platform" >}}
-[Bitnami's etcd Helm chart]: https://bitnami.com/stack/etcd/helm
 [Homebrew can run on Linux]: <https://docs.brew.sh/Homebrew-on-Linux>

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -128,10 +128,6 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 - [Running etcd as a Kubernetes StatefulSet][]
 
-## Installation on Kubernetes, using a statefulset or helm chart
-
-The etcd project does not currently maintain an official helm chart.
-
 ## Installation check
 
 For a slightly more involved sanity check of your installation, see

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -130,7 +130,7 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 ## Installation on Kubernetes, using a statefulset or helm chart
 
-The etcd project does not currently maintain a helm chart, however you can follow the instructions provided by [Bitnami's etcd Helm chart].
+The etcd project does not currently maintain an official helm chart.
 
 ## Installation check
 

--- a/content/en/docs/v3.7/install.md
+++ b/content/en/docs/v3.7/install.md
@@ -145,5 +145,4 @@ For a slightly more involved sanity check of your installation, see
 [releases]: https://github.com/etcd-io/etcd/releases/
 [tagged-release]: https://github.com/etcd-io/etcd/releases/tag/{{< param git_version_tag >}}
 [Supported platforms]: {{< relref "op-guide/supported-platform" >}}
-[Bitnami's etcd Helm chart]: https://bitnami.com/stack/etcd/helm
 [Homebrew can run on Linux]: <https://docs.brew.sh/Homebrew-on-Linux>

--- a/content/en/docs/v3.7/install.md
+++ b/content/en/docs/v3.7/install.md
@@ -128,10 +128,6 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 - [Running etcd as a Kubernetes StatefulSet][]
 
-## Installation on Kubernetes, using a statefulset or helm chart
-
-The etcd project does not currently maintain an official helm chart.
-
 ## Installation check
 
 For a slightly more involved sanity check of your installation, see

--- a/content/en/docs/v3.7/install.md
+++ b/content/en/docs/v3.7/install.md
@@ -130,7 +130,7 @@ The recommended way to install etcd on Linux is either through [pre-built binari
 
 ## Installation on Kubernetes, using a statefulset or helm chart
 
-The etcd project does not currently maintain a helm chart, however you can follow the instructions provided by [Bitnami's etcd Helm chart].
+The etcd project does not currently maintain an official helm chart.
 
 ## Installation check
 


### PR DESCRIPTION
It was noted that new Bitnami registry doesn't include etcd image in it ([Ref](https://github.com/etcd-io/etcd/issues/20450)). This PR updates the version docs to not include bitnami's helm chart suggestion as the project officially does not support chart based installation.

Closes #1049 