### PR TITLE
Addressing the different between content/en/docs/v3.6 and v3.7

### DIFF
--- a/content/en/docs/v3.7/feature-gates/index.md
+++ b/content/en/docs/v3.7/feature-gates/index.md
@@ -73,7 +73,7 @@ etcd.
 | Feature                          | Default | Stage | Details                                                                               |
 |----------------------------------|---------|-------|--------------------------------------------------------------------------------------|
 | CompactHashCheck                 | false   | Alpha |Enables to check data corruption before serving any client/peer traffic.                                                                              |
-| InitialCorruptCheck              | false   | Alpha |Enables the write transaction to use a shared buffer in its readonly check operations.                                                                           |
+| InitialCorruptCheck              | false   | Alpha |Enables leader to periodically check followers compaction hashes.                                                                           |
 | LeaseCheckpoint                  | false   | Alpha |Enables leader to send regular checkpoints to other members to prevent reset of remaining TTL on leader change.                                              |
 | LeaseCheckpointPersist           | false   | Alpha |Enables persisting remainingTTL to prevent indefinite auto-renewal of long lived leases.                                                                         |
 | SetMemberLocalAddr               | false   | Alpha |Enables using the first specified and non-loopback local address from initial-advertise-peer-urls as the local address when communicating with a peer.      |

--- a/content/en/docs/v3.7/feature-gates/index.md
+++ b/content/en/docs/v3.7/feature-gates/index.md
@@ -78,7 +78,7 @@ etcd.
 | LeaseCheckpointPersist           | false   | Alpha |Enables persisting remainingTTL to prevent indefinite auto-renewal of long lived leases.                                                                         |
 | SetMemberLocalAddr               | false   | Alpha |Enables using the first specified and non-loopback local address from initial-advertise-peer-urls as the local address when communicating with a peer.      |
 | StopGRPCServiceOnDefrag          | false   | Alpha |Enables etcd gRPC service to stop serving client requests on defragmentation.                                                                      |
-| TxnModeWriteWithSharedBuffer     | true    | Beta  |Enables leader to periodically check followers compaction hashes.                                                                               |
+| TxnModeWriteWithSharedBuffer     | true    | Beta  |Enables the write transaction to use a shared buffer in its readonly check operations.                                                                                |
 
 ## Using a feature
 

--- a/content/en/docs/v3.7/quickstart.md
+++ b/content/en/docs/v3.7/quickstart.md
@@ -45,12 +45,15 @@ cluster of etcd:
 
 Learn about more ways to configure and use etcd from the following pages:
 
-- Explore the gRPC [API][].
-- Set up a [multi-machine cluster][clustering].
-- Learn how to [configure][] etcd.
-- Find [language bindings and tools][integrations].
-- Use TLS to [secure an etcd cluster][security].
-- [Tune etcd][tuning].
+- If you are a developer:
+  - Explore the gRPC [API][].
+  - Find [language bindings and tools][integrations].
+
+- If you are an operator or admin:
+  - Set up a [multi-machine cluster][clustering].
+  - Learn how to [configure][] etcd.
+  - Use TLS to [secure an etcd cluster][security].
+  - [Tune etcd][tuning].
 
 [api]: /docs/{{< param version >}}/learning/api
 [clustering]: /docs/{{< param version >}}/op-guide/clustering


### PR DESCRIPTION
This PR is the follow up of the creation for v3.7 and addressing the different between different of content in v3.6 and v3.7 when we generating it this PR: https://github.com/etcd-io/website/pull/1019#pullrequestreview-2960053736.

Related issue: https://github.com/etcd-io/website/issues/1033