### PR TITLE
Update logging conventions to more accurately reflect zap

### DIFF
--- a/content/en/docs/v3.5/dev-internal/logging.md
+++ b/content/en/docs/v3.5/dev-internal/logging.md
@@ -20,7 +20,7 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * WarnLevel logs are more important than Info, but don't need individual human review.
   * Examples:
-    * Failure to send raft message to a remote peer
+    * Failure to send Raft message to a remote peer
     * Failure to receive heartbeat message within the configured election timeout
 
 * ErrorLevel logs are high-priority. If an application is running smoothly, it shouldn't generate any error-level logs.
@@ -29,10 +29,10 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * PanicLevel logs a message, then panics.
   * Examples:
-    * Failure to encode raft messages
+    * Failure to encode Raft messages
 
 * FatalLevel logs a message, then calls os.Exit(1).
   * Examples:
-    * Failure to save raft snapshot
+    * Failure to save Raft snapshot
 
 [zap]: https://github.com/uber-go/zap

--- a/content/en/docs/v3.6/dev-internal/logging.md
+++ b/content/en/docs/v3.6/dev-internal/logging.md
@@ -20,7 +20,7 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * WarnLevel logs are more important than Info, but don't need individual human review.
   * Examples:
-    * Failure to send raft message to a remote peer
+    * Failure to send Raft message to a remote peer
     * Failure to receive heartbeat message within the configured election timeout
 
 * ErrorLevel logs are high-priority. If an application is running smoothly, it shouldn't generate any error-level logs.
@@ -29,10 +29,10 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * PanicLevel logs a message, then panics.
   * Examples:
-    * Failure to encode raft messages
+    * Failure to encode Raft messages
 
 * FatalLevel logs a message, then calls os.Exit(1).
   * Examples:
-    * Failure to save raft snapshot
+    * Failure to save Raft snapshot
 
 [zap]: https://github.com/uber-go/zap

--- a/content/en/docs/v3.7/dev-internal/logging.md
+++ b/content/en/docs/v3.7/dev-internal/logging.md
@@ -20,7 +20,7 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * WarnLevel logs are more important than Info, but don't need individual human review.
   * Examples:
-    * Failure to send raft message to a remote peer
+    * Failure to send Raft message to a remote peer
     * Failure to receive heartbeat message within the configured election timeout
 
 * ErrorLevel logs are high-priority. If an application is running smoothly, it shouldn't generate any error-level logs.
@@ -29,10 +29,10 @@ etcd uses the [zap][zap] library for logging application output categorized into
 
 * PanicLevel logs a message, then panics.
   * Examples:
-    * Failure to encode raft messages
+    * Failure to encode Raft messages
 
 * FatalLevel logs a message, then calls os.Exit(1).
   * Examples:
-    * Failure to save raft snapshot
+    * Failure to save Raft snapshot
 
 [zap]: https://github.com/uber-go/zap


### PR DESCRIPTION
This PR makes some minor corrections to the documentation to better reflect usage of the `zap` library:

* The `Notice` level has been removed, with most messages now going to `Info`. The examples provided under `Notice` have been moved to `Info` as they are still a great example for auditing.
* The `Warning` level has been renamed to `Warn` to more closely represent the level described by `zap` (`WarnLevel`, the "warn" string used to describe the level, etc.).