### PR TITLE
Ensure v3.6 install instructions will use latest version

### DIFF
--- a/.github/workflows/update-release-version.yaml
+++ b/.github/workflows/update-release-version.yaml
@@ -17,3 +17,7 @@ jobs:
     uses: ./.github/workflows/update-release-version-template.yaml
     with:
       release: v3.5
+  v3_6:
+    uses: ./.github/workflows/update-release-version-template.yaml
+    with:
+      release: v3.6


### PR DESCRIPTION
Just noticed our install instructions for v3.6 still point users to v3.6.0 ⚠️ 

Let's ensure we get pr's automagically to bump this.