### PR TITLE
Set Upgrade update date to October 21st

### DIFF
--- a/content/en/blog/2025/upgrade_from_3.5_to_3.6_issue.md
+++ b/content/en/blog/2025/upgrade_from_3.5_to_3.6_issue.md
@@ -5,8 +5,12 @@ date: 2025-03-27
 draft: false
 ---
 
-Update (October 20, 2025): We have identified and fixed an additional scenario related to
-this issue. Please see our new blog post [Follow Up - Preventing Upgrade Failures from etcd v3.5 to v3.6][] for details.
+{{% alert title="Update (October 21, 2025)" %}}
+We have identified and fixed an additional scenario related to this issue. Please see our
+new blog post
+[Follow Up - Preventing Upgrade Failures from etcd v3.5 to v3.6](/blog/2025/upgrade_from_3.5_to_3.6_issue_followup)
+for details.
+{{% /alert %}}
 
 There is a common issue [19557][] in the etcd v3.5 to v3.6 upgrade that may cause the upgrade
 process to fail. You can find detailed information and related discussions in the issue.
@@ -75,4 +79,3 @@ test via [19634][], which was also backported to release-3.6 via [19662][].
 [19636]: https://github.com/etcd-io/etcd/pull/19636
 [19634]: https://github.com/etcd-io/etcd/pull/19634
 [19662]: https://github.com/etcd-io/etcd/pull/19662
-[Follow Up - Preventing Upgrade Failures from etcd v3.5 to v3.6]: https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue_followup/


### PR DESCRIPTION
The follow-up date in the blog post's update notice pointed to October 21. #1079 updated the blog post date, but not the follow-up text.

I'm also trying out Docsy's alert shortcode.