### PR TITLE
Adding Ronald N. to list of reviewers.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,3 +12,4 @@ approvers:
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
 reviewers:
   - wendy-ha18      # Wendy Ha <wendyha.sut@gmail.com>
+  - ronaldngounou   # Ronald Ngounou <rngounou@amazon.com>


### PR DESCRIPTION
Ronald Ngounou has completed the SIG Etcd Docs mentorship cohort.  He has shown his good work updating documentation, editing documentation submissions, and helping weed the list of documentation issues.  As such, we'd like to make him a reviewer.

@ivanvc @spzala  please approve?