### PR TITLE
Add general info on upgrade policy to main upgrade doc

### DIFF
--- a/content/en/docs/v3.4/upgrades/upgrading-etcd.md
+++ b/content/en/docs/v3.4/upgrades/upgrading-etcd.md
@@ -6,18 +6,26 @@ description: Documentation list for upgrading etcd clusters and applications
 
 This section contains documents specific to upgrading etcd clusters and applications.
 
+## Upgrade policy
+
+Before upgrading, note that etcd only supports the following two upgrade cases:
+
+* **Patch upgrade:** Upgrading between patch releases within the same minor version (e.g. 3.4.18 - 3.4.20).
+* **Minor upgrade:** Upgrading one minor version at a time (e.g. 3.3 - 3.4). Upgrades that skip a minor version are not supported and will likely fail. Update to the most recent patch version before upgrading to the next minor version.
+
 ## Moving from etcd API v2 to API v3
 
 * [Migrate applications from using API v2 to API v3][migrate-apps]
 
 ## Upgrading an etcd v3.x cluster
+
 * [Upgrade etcd from 3.0 to 3.1](../upgrade_3_1/)
 * [Upgrade etcd from 3.1 to 3.2](../upgrade_3_2/)
 * [Upgrade etcd from 3.2 to 3.3](../upgrade_3_3/)
 * [Upgrade etcd from 3.3 to 3.4](../upgrade_3_4/)
 
 ## Upgrading from etcd v2.3
-* [Upgrade a v2.3 cluster to v3.0](../upgrade_3_0/)
 
+* [Upgrade a v2.3 cluster to v3.0](../upgrade_3_0/)
 
 [migrate-apps]: ../../op-guide/v2-migration/

--- a/content/en/docs/v3.5/upgrades/upgrading-etcd.md
+++ b/content/en/docs/v3.5/upgrades/upgrading-etcd.md
@@ -6,7 +6,15 @@ description: Documentation list for upgrading etcd clusters and applications
 
 This section contains documents specific to upgrading etcd clusters and applications.
 
+## Upgrade policy
+
+Before upgrading, note that etcd only supports the following two upgrade cases:
+
+* **Patch upgrade:** Upgrading between patch releases within the same minor version (e.g. 3.5.23 - 3.5.26).
+* **Minor upgrade:** Upgrading one minor version at a time (e.g. 3.4 - 3.5). Upgrades that skip a minor version are not supported and will likely fail. Update to the most recent patch version before upgrading to the next minor version.
+
 ## Upgrading an etcd v3.x cluster
+
 * [Upgrade etcd from 3.0 to 3.1](../upgrade_3_1/)
 * [Upgrade etcd from 3.1 to 3.2](../upgrade_3_2/)
 * [Upgrade etcd from 3.2 to 3.3](../upgrade_3_3/)
@@ -14,7 +22,5 @@ This section contains documents specific to upgrading etcd clusters and applicat
 * [Upgrade etcd from 3.4 to 3.5](../upgrade_3_5/)
 
 ## Upgrading from etcd v2.3
+
 * [Upgrade a v2.3 cluster to v3.0](../upgrade_3_0/)
-
-
-[migrate-apps]: ../../op-guide/v2-migration/

--- a/content/en/docs/v3.6/upgrades/upgrading-etcd.md
+++ b/content/en/docs/v3.6/upgrades/upgrading-etcd.md
@@ -6,6 +6,13 @@ description: Documentation list for upgrading etcd clusters and applications
 
 This section contains documents specific to upgrading etcd clusters and applications.
 
+## Upgrade policy
+
+Before upgrading, note that etcd only supports the following two upgrade cases:
+
+* **Patch upgrade:** Upgrading between patch releases within the same minor version (e.g. 3.6.0 - 3.6.2).
+* **Minor upgrade:** Upgrading one minor version at a time (e.g. 3.5 - 3.6). Upgrades that skip a minor version are not supported and will likely fail. Update to the most recent patch version before upgrading to the next minor version.
+
 ## Upgrading an etcd v3.x cluster
 
 * [Upgrade etcd from 3.0 to 3.1](../upgrade_3_1/)
@@ -18,5 +25,3 @@ This section contains documents specific to upgrading etcd clusters and applicat
 ## Upgrading from etcd v2.3
 
 * [Upgrade a v2.3 cluster to v3.0](../upgrade_3_0/)
-
-[migrate-apps]: ../../op-guide/v2-migration/

--- a/content/en/docs/v3.7/upgrades/upgrading-etcd.md
+++ b/content/en/docs/v3.7/upgrades/upgrading-etcd.md
@@ -6,6 +6,13 @@ description: Documentation list for upgrading etcd clusters and applications
 
 This section contains documents specific to upgrading etcd clusters and applications.
 
+## Upgrade policy
+
+Before upgrading, note that etcd only supports the following two upgrade cases:
+
+* **Patch upgrade:** Upgrading between patch releases within the same minor version (e.g. 3.7.0 - 3.7.1).
+* **Minor upgrade:** Upgrading one minor version at a time (e.g. 3.6 - 3.7). Upgrades that skip a minor version are not supported and will likely fail. Update to the most recent patch version before upgrading to the next minor version.
+
 ## Upgrading an etcd v3.x cluster
 
 * [Upgrade etcd from 3.0 to 3.1](../upgrade_3_1/)
@@ -18,5 +25,3 @@ This section contains documents specific to upgrading etcd clusters and applicat
 ## Upgrading from etcd v2.3
 
 * [Upgrade a v2.3 cluster to v3.0](../upgrade_3_0/)
-
-[migrate-apps]: ../../op-guide/v2-migration/


### PR DESCRIPTION
Add version-agnostic upgrade policies/advice for the Etcd subproject:
- Only upgrades across one minor version are supported (e.g. 3.4 to 3.5)
- Users should update to the most recent patch version before upgrading minor versions
- Upgrades from EOL versions may work but are no longer supported

Fixes DONE

Fixes #1114