### PR TITLE
docs: clarify security implications of space quotas

### DIFF
--- a/content/en/docs/v3.5/op-guide/maintenance.md
+++ b/content/en/docs/v3.5/op-guide/maintenance.md
@@ -108,6 +108,8 @@ $ etcdctl defrag --data-dir <path-to-etcd-data-dir>
 
 The space quota in `etcd` ensures the cluster operates in a reliable fashion. Without a space quota, `etcd` may suffer from poor performance if the keyspace grows excessively large, or it may simply run out of storage space, leading to unpredictable cluster behavior. If the keyspace's backend database for any member exceeds the space quota, `etcd` raises a cluster-wide alarm that puts the cluster into a maintenance mode which only accepts key reads and deletes. Only after freeing enough space in the keyspace and defragmenting the backend database, along with clearing the space quota alarm can the cluster resume normal operation.
 
+Setting a space quota also helps mitigate Denial of Service (DoS) attacks that target disk exhaustion. `etcd` checks the quota at both the API layer (early rejection) and the Apply layer (raising a `NOSPACE` alarm), limiting the impact of excessive write requests on cluster resources. See the note at the end of this section for details on how these two checks interact.
+
 By default, `etcd` sets a conservative space quota suitable for most applications, but it may be configured on the command line, in bytes:
 
 ```sh


### PR DESCRIPTION
### What is this change?
Adds a security-focused note to help the Space Quota section in the Maintenance Guide, highlighting that quotas help mitigate DoS attacks targeting disk exhaustion.

### Why is this change necessary?
The existing docs explain quota behavior (what happens when space runs out), but don't mention the security angle — that quotas also limit the impact of excessive write requests from an attacker.

This note complements the existing NOTE about two-layer quota checks 
(API layer + Apply layer) by adding the security perspective.

## Code references
- API layer check: server/etcdserver/api/v3rpc/quota.go — rejects writes early
- Apply layer check: server/etcdserver/apply/quota.go — raises NOSPACE alarm
- Related issue: etcd#16659

## Changes
- Added a blockquote note mentioning DoS mitigation
- References both API and Apply layer checks
- Points readers to the existing behavior note at the end of the section