### PR TITLE
upgrade-etcd.md: add a paragraph about the supported upgrade path

### DIFF
--- a/content/en/docs/v3.4/upgrades/_index.md
+++ b/content/en/docs/v3.4/upgrades/_index.md
@@ -3,3 +3,11 @@ title: Upgrading
 weight: 6000
 description: Upgrading etcd clusters and applications
 ---
+
+## Supported upgrade path
+
+etcd only supports upgrades in the following two cases:
+
+- Upgrading between patch releases within the same minor version.
+- Upgrading from the current version to the next minor version, or to the next major
+version, if the current minor version is the last minor of the current major.

--- a/content/en/docs/v3.5/upgrades/_index.md
+++ b/content/en/docs/v3.5/upgrades/_index.md
@@ -3,3 +3,11 @@ title: Upgrading
 weight: 6000
 description: Upgrading etcd clusters and applications
 ---
+
+## Supported upgrade path
+
+etcd only supports upgrades in the following two cases:
+
+- Upgrading between patch releases within the same minor version.
+- Upgrading from the current version to the next minor version, or to the next major
+version, if the current minor version is the last minor of the current major.

--- a/content/en/docs/v3.6/upgrades/_index.md
+++ b/content/en/docs/v3.6/upgrades/_index.md
@@ -3,3 +3,11 @@ title: Upgrading
 weight: 6000
 description: Upgrading etcd clusters and applications
 ---
+
+## Supported upgrade path
+
+etcd only supports upgrades in the following two cases:
+
+- Upgrading between patch releases within the same minor version.
+- Upgrading from the current version to the next minor version, or to the next major
+version, if the current minor version is the last minor of the current major.

--- a/content/en/docs/v3.7/upgrades/_index.md
+++ b/content/en/docs/v3.7/upgrades/_index.md
@@ -3,3 +3,11 @@ title: Upgrading
 weight: 6000
 description: Upgrading etcd clusters and applications
 ---
+
+## Supported upgrade path
+
+etcd only supports upgrades in the following two cases:
+
+- Upgrading between patch releases within the same minor version.
+- Upgrading from the current version to the next minor version, or to the next major
+version, if the current minor version is the last minor of the current major.


### PR DESCRIPTION
Add a paragraph explaining how the supported upgrade path of etcd works. Include all versions in support 3.4 - 3.7.

happy to adjust the wording or the target .md files if needed.

xref https://github.com/etcd-io/etcd-operator/issues/168#issuecomment-3843253447

/assign @ahrtr 
