### PR TITLE
docs: clarify that /metrics endpoint requires separate authentication

### DIFF
--- a/content/en/docs/v3.5/op-guide/authentication/rbac.md
+++ b/content/en/docs/v3.5/op-guide/authentication/rbac.md
@@ -147,6 +147,18 @@ After this, etcd is running with authentication enabled. To disable it for any r
 $ etcdctl --user root:rootpw auth disable
 ```
 
+## Security Scope of Authentication
+
+When authentication is enabled with `etcdctl auth enable`, it protects the V3 gRPC API operations (get, put, delete, watch, etc.).
+
+The `/metrics` and `/health` HTTP endpoints operate on a separate handler and are **not** protected by V3 RBAC authentication. This design allows Prometheus and load balancers to scrape metrics without requiring gRPC authentication, while still protecting the key-value data.
+
+To secure these observability endpoints:
+
+- Enable mTLS with `--cert-file`, `--key-file`, and `--client-cert-auth`
+- Or bind metrics to a private interface using `--listen-metrics-urls`
+- Or use network policies/firewall rules to restrict access
+
 ## Using `etcdctl` to authenticate
 
 `etcdctl` supports a similar flag as `curl` for authentication.

--- a/content/en/docs/v3.6/op-guide/authentication/rbac.md
+++ b/content/en/docs/v3.6/op-guide/authentication/rbac.md
@@ -155,6 +155,18 @@ After this, etcd is running with authentication enabled. To disable it for any r
 $ etcdctl --user root:rootpw auth disable
 ```
 
+## Security Scope of Authentication
+
+When authentication is enabled with `etcdctl auth enable`, it protects the V3 gRPC API operations (get, put, delete, watch, etc.).
+
+The `/metrics` and `/health` HTTP endpoints operate on a separate handler and are **not** protected by V3 RBAC authentication. This design allows Prometheus and load balancers to scrape metrics without requiring gRPC authentication, while still protecting the key-value data.
+
+To secure these observability endpoints:
+
+- Enable mTLS with `--cert-file`, `--key-file`, and `--client-cert-auth`
+- Or bind metrics to a private interface using `--listen-metrics-urls`
+- Or use network policies/firewall rules to restrict access
+
 ## Using `etcdctl` to authenticate
 
 `etcdctl` supports a similar flag as `curl` for authentication.

--- a/content/en/docs/v3.7/op-guide/authentication/rbac.md
+++ b/content/en/docs/v3.7/op-guide/authentication/rbac.md
@@ -155,6 +155,18 @@ After this, etcd is running with authentication enabled. To disable it for any r
 $ etcdctl --user root:rootpw auth disable
 ```
 
+## Security Scope of Authentication
+
+When authentication is enabled with `etcdctl auth enable`, it protects the V3 gRPC API operations (get, put, delete, watch, etc.).
+
+The `/metrics` and `/health` HTTP endpoints operate on a separate handler and are **not** protected by V3 RBAC authentication. This design allows Prometheus and load balancers to scrape metrics without requiring gRPC authentication, while still protecting the key-value data.
+
+To secure these observability endpoints:
+
+- Enable mTLS with `--cert-file`, `--key-file`, and `--client-cert-auth`
+- Or bind metrics to a private interface using `--listen-metrics-urls`
+- Or use network policies/firewall rules to restrict access
+
 ## Using `etcdctl` to authenticate
 
 `etcdctl` supports a similar flag as `curl` for authentication.


### PR DESCRIPTION
### What is this change?

This PR adds a security clarification note to the RBAC documentation explaining that the `/metrics` and `/health` HTTP endpoints are **not** protected by V3 RBAC authentication (`auth enable`).

### Why is this needed?

Operators may assume that enabling authentication with `etcdctl auth enable` protects all endpoints. However, the `/metrics` endpoint uses a separate HTTP handler and requires mTLS or network isolation for protection.

**Code references:**
- Auth enforcement (reads): server/etcdserver/v3_server.go - AuthInfoFromCtx, IsRangePermitted
- Auth enforcement (writes): server/etcdserver/apply/auth.go - IsPutPermitted
- Metrics handler: server/embed/etcd.go - separate HTTP handler, no auth

### Changes

- Added a "Security Scope of Authentication" section to rbac.md
- Clarifies that auth enable protects gRPC API operations only
- Notes that /metrics and /health bypass gRPC auth
- Provides mitigation options (mTLS, --listen-metrics-urls, network policies)

### Related

- Analysis: https://gist.github.com/pigeio/2f2c7dfe387374434a72dbb2e4b40ff0