### PR TITLE
docs: add prerequisites, examples, and release info to locks tutorial

### DIFF
--- a/content/en/docs/v3.6/tasks/developer/how-to-create-locks.md
+++ b/content/en/docs/v3.6/tasks/developer/how-to-create-locks.md
@@ -9,17 +9,39 @@ LOCK acquires a distributed mutex with a given name. Once the lock is acquired, 
 ## Prerequisites
 
 * Install [`etcd` and `etcdctl`](https://etcd.io/docs/v3.6/install/)
+* A running etcd cluster (see [How to Set Up a Demo etcd Cluster](/docs/v3.6/tasks/operator/how-to-setup-cluster/))
 
 ## Creating a lock
 
-`lock` for distributed lock:
-
-![08_etcdctl_lock_2016050501](https://storage.googleapis.com/etcd/demo/08_etcdctl_lock_2016050501.gif)
-
+Acquire a lock with a specified name:
 ```shell
 etcdctl --endpoints=$ENDPOINTS lock mutex1
 ```
 
-### Options
-- endpoints - defines a comma-delimited list of machine addresses in the cluster.
-- ttl - time out in seconds of lock session.
+The lock will be held until the command is terminated with `Ctrl+C`.
+
+### Lock with command execution
+
+You can also execute a command while holding the lock:
+```shell
+etcdctl --endpoints=$ENDPOINTS lock mutex1 echo "Lock acquired"
+```
+
+When using this form, the lock is automatically released after the command completes.
+
+### Visual demonstration
+
+![08_etcdctl_lock_2016050501](https://storage.googleapis.com/etcd/demo/08_etcdctl_lock_2016050501.gif)
+
+## Options
+
+- `--endpoints` - Comma-delimited list of etcd cluster endpoints (default: `http://127.0.0.1:2379`)
+- `--ttl` - Time to live in seconds for the lock session (default: 60)
+
+## Releasing a lock
+
+Locks are released in the following ways:
+
+- **Manual release**: Press `Ctrl+C` to terminate the etcdctl lock command
+- **Automatic release**: When executing a command with the lock, it is released after the command completes
+- **TTL expiration**: The lock automatically expires after the TTL period if not renewed


### PR DESCRIPTION
## Summary

Adds missing prerequisites, command execution example, and lock release documentation to the locks tutorial.

## Changes

- Added cluster setup prerequisite
- Added command execution example with auto-release
- Documented three lock release methods
- Added default values to `--endpoints` and `--ttl` options

## Context

Addresses part of #794 by filling straightforward documentation gaps. Further improvements (multi-client examples, detailed mechanics) will follow in subsequent PRs.

## Testing

- [x] Tested locally with `npm run serve`
- [x] Verified markdown and links render correctly