### PR TITLE
docs: document x509 keyUsage and extendedKeyUsage for etcd TLS

### DIFF
--- a/content/en/docs/v3.7/op-guide/security.md
+++ b/content/en/docs/v3.7/op-guide/security.md
@@ -52,6 +52,30 @@ If either a client-to-server or peer certificate is supplied the key must also b
 
 `--tls-max-version=<version>` Sets the maximum TLS version supported by etcd. If not set the maximum version supported by Go will be used.
 
+### TLS certificate keyUsage and extendedKeyUsage
+
+When generating X.509 certificates for securing etcd transport,
+certificates should include appropriate `keyUsage` and
+`extendedKeyUsage` fields depending on their role. etcd relies on Go’s
+`crypto/tls` and `crypto/x509` libraries for certificate verification,
+which enforce these usages during the TLS handshake.
+
+The following table summarizes the recommended usages for common certificate roles:
+
+| Certificate role | keyUsage | extendedKeyUsage |
+| ---------------- | -------- | ---------------- |
+| Server (client-to-server) | digitalSignature, keyEncipherment | serverAuth |
+| Client | digitalSignature, keyEncipherment | clientAuth |
+| Peer (server-to-server) | digitalSignature, keyEncipherment | serverAuth, clientAuth |
+
+Notes:
+
+- When `--peer-client-cert-auth` is enabled, peer certificates are
+  used for mutual TLS between etcd members and therefore require both
+  `serverAuth` and `clientAuth`.
+- Client certificates used with `--client-cert-auth` should include
+  `clientAuth`.
+
 ## Example 1: Client-to-server transport security with HTTPS
 
 For this, have a CA certificate (`ca.crt`) and signed key pair (`server.crt`, `server.key`) ready.


### PR DESCRIPTION
This PR documents recommended X.509 `keyUsage` and `extendedKeyUsage`
values for certificates used to secure etcd transport (CA, server,
client, and peer).

This clarifies existing behavior enforced by Go's `crypto/tls` and
`crypto/x509` libraries.

Fixes etcd-io/etcd#19799

Docs-only change.
