### PR TITLE
Promote Wendy and Ronald to approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,4 +10,4 @@ approvers:
   - spzala          # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
   - wendy-ha18      # Wendy Ha <wendyha.sut@gmail.com>
-  - ronaldngounou   # Ronald Ngounou <rngounou@amazon.com>
+  - ronaldngounou   # Ronald Ngounou <ronald.ngounou@yahoo.com>


### PR DESCRIPTION
Given that they have continued their work reviewing etcd doc patches, and done a terrific job reviewing, as well as discussing direction and needs for the etcd docs, this PR promotes @wendy-ha18  and @ronaldngounou to documentation approvers.  It will be followed by the  required updates to kubernetes/org.

This PR also removes James Blair from approvers due to his retirement from the SIG.

@ivanvc @spzala @nate-double-u 