### PR TITLE
docs: fix disaster recovery examples

### DIFF
--- a/content/en/docs/v3.5/op-guide/recovery.md
+++ b/content/en/docs/v3.5/op-guide/recovery.md
@@ -79,6 +79,7 @@ When restoring from a snapshot, you can directly supply the new membership into 
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
+  --data-dir m1.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
@@ -102,16 +103,19 @@ Continuing from the previous example, the following creates new etcd data direct
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
+  --data-dir m1.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m2 \
+  --data-dir m2.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host2:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m3 \
+  --data-dir m3.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host3:2380
@@ -122,16 +126,19 @@ Next, start `etcd` with the new data directories:
 ```sh
 $ etcd \
   --name m1 \
+  --data-dir m1.etcd \
   --listen-client-urls http://host1:2379 \
   --advertise-client-urls http://host1:2379 \
   --listen-peer-urls http://host1:2380 &
 $ etcd \
   --name m2 \
+  --data-dir m2.etcd \
   --listen-client-urls http://host2:2379 \
   --advertise-client-urls http://host2:2379 \
   --listen-peer-urls http://host2:2380 &
 $ etcd \
   --name m3 \
+  --data-dir m3.etcd \
   --listen-client-urls http://host3:2379 \
   --advertise-client-urls http://host3:2379 \
   --listen-peer-urls http://host3:2380 &

--- a/content/en/docs/v3.6/op-guide/recovery.md
+++ b/content/en/docs/v3.6/op-guide/recovery.md
@@ -79,6 +79,7 @@ When restoring from a snapshot, you can directly supply the new membership into 
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
+  --data-dir m1.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
@@ -102,19 +103,19 @@ Continuing from the previous example, the following creates new etcd data direct
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
-  --data-dir m1_data_dir.etcd
+  --data-dir m1_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m2 \
-  --data-dir m2_data_dir.etcd
+  --data-dir m2_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host2:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m3 \
-  --data-dir m3_data_dir.etcd
+  --data-dir m3_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host3:2380
@@ -125,19 +126,19 @@ Next, start `etcd` with the new data directories:
 ```sh
 $ etcd \
   --name m1 \
-  --data-dir m1_data_dir.etcd
+  --data-dir m1_data_dir.etcd \
   --listen-client-urls http://host1:2379 \
   --advertise-client-urls http://host1:2379 \
   --listen-peer-urls http://host1:2380 &
 $ etcd \
   --name m2 \
-  --data-dir m2_data_dir.etcd
+  --data-dir m2_data_dir.etcd \
   --listen-client-urls http://host2:2379 \
   --advertise-client-urls http://host2:2379 \
   --listen-peer-urls http://host2:2380 &
 $ etcd \
   --name m3 \
-  --data-dir m3_data_dir.etcd
+  --data-dir m3_data_dir.etcd \
   --listen-client-urls http://host3:2379 \
   --advertise-client-urls http://host3:2379 \
   --listen-peer-urls http://host3:2380 &

--- a/content/en/docs/v3.7/op-guide/recovery.md
+++ b/content/en/docs/v3.7/op-guide/recovery.md
@@ -79,6 +79,7 @@ When restoring from a snapshot, you can directly supply the new membership into 
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
+  --data-dir m1.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
@@ -102,19 +103,19 @@ Continuing from the previous example, the following creates new etcd data direct
 ```sh
 $ etcdutl snapshot restore snapshot.db \
   --name m1 \
-  --data-dir m1_data_dir.etcd
+  --data-dir m1_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host1:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m2 \
-  --data-dir m2_data_dir.etcd
+  --data-dir m2_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host2:2380
 $ etcdutl snapshot restore snapshot.db \
   --name m3 \
-  --data-dir m3_data_dir.etcd
+  --data-dir m3_data_dir.etcd \
   --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
   --initial-cluster-token etcd-cluster-1 \
   --initial-advertise-peer-urls http://host3:2380
@@ -125,19 +126,19 @@ Next, start `etcd` with the new data directories:
 ```sh
 $ etcd \
   --name m1 \
-  --data-dir m1_data_dir.etcd
+  --data-dir m1_data_dir.etcd \
   --listen-client-urls http://host1:2379 \
   --advertise-client-urls http://host1:2379 \
   --listen-peer-urls http://host1:2380 &
 $ etcd \
   --name m2 \
-  --data-dir m2_data_dir.etcd
+  --data-dir m2_data_dir.etcd \
   --listen-client-urls http://host2:2379 \
   --advertise-client-urls http://host2:2379 \
   --listen-peer-urls http://host2:2380 &
 $ etcd \
   --name m3 \
-  --data-dir m3_data_dir.etcd
+  --data-dir m3_data_dir.etcd \
   --listen-client-urls http://host3:2379 \
   --advertise-client-urls http://host3:2379 \
   --listen-peer-urls http://host3:2380 &


### PR DESCRIPTION
## Summary
- **v3.5**: Add missing `--data-dir` flag to `etcdutl snapshot restore` and `etcd` start commands in both the "Restoring with updated membership" and end-to-end example sections. In v3.5, `--data-dir` is required and omitting it causes the restore to fail.
- **v3.6, v3.7**: Add missing `--data-dir` to the "Restoring with updated membership" section for consistency. Fix missing line-continuation backslashes (`\`) after `--data-dir` in end-to-end examples, which caused the shell to interpret them as separate commands.

Fixes #1092

## Test plan
- [ ] Verify the corrected commands work with `etcdutl snapshot restore` on each version
- [ ] Verify line continuations render correctly in the Hugo site