### PR TITLE
docs: clarify that duration fields in config files require nanosecond integers

### DIFF
--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -308,8 +308,9 @@ For example, to set a 10-minute watch progress notify interval in a config file:
 experimental-watch-progress-notify-interval: 600000000000
 
 # Incorrect: will produce an unmarshal error
-# experimental-watch-progress-notify-interval: '10m'
+experimental-watch-progress-notify-interval: '10m'
 ```
+
 {{% /alert %}}
 
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go

--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -290,6 +290,28 @@ In order to use this file, specify the file path as a value to the `--config-fil
 
 For an example, see the [etcd.conf.yml sample][].
 
+{{% alert title="Note" color="info" %}}
+Duration fields such as `--grpc-keepalive-min-time`, `--grpc-keepalive-interval`,
+`--grpc-keepalive-timeout`, `--backend-batch-interval`,
+`--experimental-corrupt-check-time`,
+`--experimental-watch-progress-notify-interval`, and
+`--experimental-warning-apply-duration` accept human-readable strings (e.g.
+`10m`, `5s`) when passed as command-line flags, but in a configuration file they
+only accept **integer values representing nanoseconds**. This is a
+[known Go standard library limitation](https://github.com/golang/go/issues/10275)
+where `time.Duration` is unmarshaled as a plain integer.
+
+For example, to set a 10-minute watch progress notify interval in a config file:
+
+```yaml
+# Correct: 10 minutes in nanoseconds
+experimental-watch-progress-notify-interval: 600000000000
+
+# Incorrect: will produce an unmarshal error
+# experimental-watch-progress-notify-interval: '10m'
+```
+{{% /alert %}}
+
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go
 [etcd.conf.yml sample]: https://github.com/etcd-io/etcd/blob/main/etcd.conf.yml.sample
 [snake case]: https://en.wikipedia.org/wiki/Snake_case

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -306,6 +306,28 @@ In order to use this file, specify the file path as a value to the `--config-fil
 
 For an example, see the [etcd.conf.yml sample][].
 
+{{% alert title="Note" color="info" %}}
+Duration fields such as `--grpc-keepalive-min-time`, `--grpc-keepalive-interval`,
+`--grpc-keepalive-timeout`, `--backend-batch-interval`,
+`--experimental-corrupt-check-time`,
+`--experimental-watch-progress-notify-interval`, and
+`--experimental-warning-apply-duration` accept human-readable strings (e.g.
+`10m`, `5s`) when passed as command-line flags, but in a configuration file they
+only accept **integer values representing nanoseconds**. This is a
+[known Go standard library limitation](https://github.com/golang/go/issues/10275)
+where `time.Duration` is unmarshaled as a plain integer.
+
+For example, to set a 10-minute watch progress notify interval in a config file:
+
+```yaml
+# Correct: 10 minutes in nanoseconds
+experimental-watch-progress-notify-interval: 600000000000
+
+# Incorrect: will produce an unmarshal error
+# experimental-watch-progress-notify-interval: '10m'
+```
+{{% /alert %}}
+
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go
 [etcd.conf.yml sample]: https://github.com/etcd-io/etcd/blob/main/etcd.conf.yml.sample
 [snake case]: https://en.wikipedia.org/wiki/Snake_case

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -324,8 +324,9 @@ For example, to set a 10-minute watch progress notify interval in a config file:
 experimental-watch-progress-notify-interval: 600000000000
 
 # Incorrect: will produce an unmarshal error
-# experimental-watch-progress-notify-interval: '10m'
+experimental-watch-progress-notify-interval: '10m'
 ```
+
 {{% /alert %}}
 
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go

--- a/content/en/docs/v3.7/op-guide/configuration.md
+++ b/content/en/docs/v3.7/op-guide/configuration.md
@@ -340,6 +340,28 @@ In order to use this file, specify the file path as a value to the `--config-fil
 
 For an example, see the [etcd.conf.yml sample][].
 
+{{% alert title="Note" color="info" %}}
+Duration fields such as `--grpc-keepalive-min-time`, `--grpc-keepalive-interval`,
+`--grpc-keepalive-timeout`, `--backend-batch-interval`, `--corrupt-check-time`,
+`--compact-hash-check-time`, `--compaction-sleep-interval`,
+`--watch-progress-notify-interval`, `--warning-apply-duration`,
+`--warning-unary-request-duration`, and `--downgrade-check-time` accept
+human-readable strings (e.g. `10m`, `5s`) when passed as command-line flags, but
+in a configuration file they only accept **integer values representing
+nanoseconds**. This is a [known Go standard library limitation](https://github.com/golang/go/issues/10275)
+where `time.Duration` is unmarshaled as a plain integer.
+
+For example, to set a 10-minute watch progress notify interval in a config file:
+
+```yaml
+# Correct: 10 minutes in nanoseconds
+watch-progress-notify-interval: 600000000000
+
+# Incorrect: will produce an unmarshal error
+# watch-progress-notify-interval: '10m'
+```
+{{% /alert %}}
+
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go
 [etcd.conf.yml sample]: https://github.com/etcd-io/etcd/blob/main/etcd.conf.yml.sample
 [snake case]: https://en.wikipedia.org/wiki/Snake_case

--- a/content/en/docs/v3.7/op-guide/configuration.md
+++ b/content/en/docs/v3.7/op-guide/configuration.md
@@ -358,8 +358,9 @@ For example, to set a 10-minute watch progress notify interval in a config file:
 watch-progress-notify-interval: 600000000000
 
 # Incorrect: will produce an unmarshal error
-# watch-progress-notify-interval: '10m'
+watch-progress-notify-interval: '10m'
 ```
+
 {{% /alert %}}
 
 [etcd help]: https://github.com/etcd-io/etcd/blob/main/server/etcdmain/help.go


### PR DESCRIPTION
## Summary
- Documents that `time.Duration` fields in etcd configuration files only accept integer values (nanoseconds), not human-readable duration strings like `10m` or `5s`
- Lists all affected duration fields per version
- Includes a correct/incorrect YAML example using `watch-progress-notify-interval`
- Applied to v3.5, v3.6, and v3.7 docs with version-appropriate flag names (v3.5/v3.6 use `experimental-` prefixes)

This is a known Go standard library limitation ([golang/go#10275](https://github.com/golang/go/issues/10275)) where `time.Duration` is unmarshaled as a plain `int64`. CLI flags work with duration strings because they use `flag.DurationVar`, but the config file parser uses Go's default JSON/YAML unmarshaler.

Ref: etcd-io/etcd#20342