### PR TITLE
docs: remove references to play.etcd.io

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -2,7 +2,6 @@ DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreURLs:
-  - "^http://play.etcd.io.*"
   # Manually verified external links below this point
   - "^https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations"
   - "^https://www.consul.io/docs/dynamic-app-config/sessions"

--- a/config.yaml
+++ b/config.yaml
@@ -211,5 +211,3 @@ menu:
       pageref: /blog/
     - name: Install
       url: /docs/latest/install/
-    - name: Play
-      url: http://play.etcd.io/play


### PR DESCRIPTION
Closes etcd-io/etcd#1166
Removed all references to play.etcd.io as the playground is no longer being maintained:
- Removed the "Play" navigation link from config.yaml
- Removed the play.etcd.io URL ignore rule from .htmltest.yml

References in pre-v3.5 blog posts and old documentation were left untouched per the issue instructions.