### PR TITLE
docs: revise lease tutorial with prerequisites and sections

### DIFF
--- a/content/en/docs/v3.5/tutorials/how-to-create-lease.md
+++ b/content/en/docs/v3.5/tutorials/how-to-create-lease.md
@@ -1,23 +1,57 @@
 ---
-title: How to create lease
-description: Guide to creating a lease in etcd
+title: Granting and revoking leases
+description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
-`lease` to write with TTL:
+## Prerequisites
 
+- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
+- `etcdctl` installed and configured
 
-![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+The following variables are used in this guide:
 
-```shell
+- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
+- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
+- `put --lease` — attaches a key to a lease so it expires with it
+- `lease keep-alive` — refreshes a lease to prevent it from expiring
+- `lease revoke` — immediately expires a lease and deletes its keys
+
+For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+
+## Grant a lease
+
+Grant a lease with a TTL of 300 seconds:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
+```
 
+Attach a key to the lease so it is automatically deleted when the lease expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
+```
 
+Keep the lease alive by refreshing it before it expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
+```
+
+## Revoke a lease
+
+Revoke the lease immediately, which also deletes all keys attached to it:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
-# or after 300 seconds
+```
+
+After revocation (or after the TTL expires), the key is no longer accessible:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS get sample
+# (empty response)
 ```

--- a/content/en/docs/v3.5/tutorials/how-to-create-lease.md
+++ b/content/en/docs/v3.5/tutorials/how-to-create-lease.md
@@ -4,54 +4,67 @@ description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
+A lease is a time-to-live (TTL) that keys can be attached to. When the lease
+expires or is revoked, etcd automatically deletes every key attached to it.
+
 ## Prerequisites
 
-- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
-- `etcdctl` installed and configured
+* Install [`etcd` and `etcdctl`](https://etcd.io/docs/v3.5/install/).
+* A running `etcd` cluster.
 
-The following variables are used in this guide:
+## Terminology
 
-- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
-- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
-- `put --lease` — attaches a key to a lease so it expires with it
-- `lease keep-alive` — refreshes a lease to prevent it from expiring
-- `lease revoke` — immediately expires a lease and deletes its keys
+Here are definitions of the commands and flags used in the examples below.
 
-For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+| Term | Definition |
+| --- | --- |
+| `--endpoints` | A comma-delimited list of machine addresses in the cluster, for example `localhost:2379`. |
+| `lease grant` | Creates a new lease with a TTL, given in seconds. Returns a lease ID. |
+| `put` | Writes a value to a key. |
+| `value` | The value written to the key in the examples below. |
+| `--lease` | Attaches a key to a lease, so the key is deleted when the lease expires. |
+| `get` | Reads the value of a key. |
+| `lease keep-alive` | Refreshes a lease so that it does not expire. |
+| `lease revoke` | Expires a lease immediately, deleting all keys attached to it. |
+
+For more information on leases, see
+[Interacting with etcd: Grant leases](https://etcd.io/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
 
 ## Grant a lease
 
+![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+
 Grant a lease with a TTL of 300 seconds:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
 ```
 
-Attach a key to the lease so it is automatically deleted when the lease expires:
+Attach a key to the lease, so that the key is deleted when the lease expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
 ```
 
 Keep the lease alive by refreshing it before it expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
 ```
 
 ## Revoke a lease
 
-Revoke the lease immediately, which also deletes all keys attached to it:
+Revoke the lease immediately. This also deletes every key attached to it:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
 ```
 
-After revocation (or after the TTL expires), the key is no longer accessible:
+After the lease is revoked, or after its TTL expires, the attached key is gone:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS get sample
 # (empty response)
 ```

--- a/content/en/docs/v3.6/tasks/developer/how-to-create-lease.md
+++ b/content/en/docs/v3.6/tasks/developer/how-to-create-lease.md
@@ -1,23 +1,57 @@
 ---
-title: How to create lease
-description: Guide to creating a lease in etcd
+title: Granting and revoking leases
+description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
-`lease` to write with TTL:
+## Prerequisites
 
+- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
+- `etcdctl` installed and configured
 
-![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+The following variables are used in this guide:
 
-```shell
+- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
+- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
+- `put --lease` — attaches a key to a lease so it expires with it
+- `lease keep-alive` — refreshes a lease to prevent it from expiring
+- `lease revoke` — immediately expires a lease and deletes its keys
+
+For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+
+## Grant a lease
+
+Grant a lease with a TTL of 300 seconds:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
+```
 
+Attach a key to the lease so it is automatically deleted when the lease expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
+```
 
+Keep the lease alive by refreshing it before it expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
+```
+
+## Revoke a lease
+
+Revoke the lease immediately, which also deletes all keys attached to it:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
-# or after 300 seconds
+```
+
+After revocation (or after the TTL expires), the key is no longer accessible:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS get sample
+# (empty response)
 ```

--- a/content/en/docs/v3.6/tasks/developer/how-to-create-lease.md
+++ b/content/en/docs/v3.6/tasks/developer/how-to-create-lease.md
@@ -4,54 +4,67 @@ description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
+A lease is a time-to-live (TTL) that keys can be attached to. When the lease
+expires or is revoked, etcd automatically deletes every key attached to it.
+
 ## Prerequisites
 
-- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
-- `etcdctl` installed and configured
+* Install [`etcd` and `etcdctl`](https://etcd.io/docs/v3.6/install/).
+* A running `etcd` cluster.
 
-The following variables are used in this guide:
+## Terminology
 
-- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
-- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
-- `put --lease` — attaches a key to a lease so it expires with it
-- `lease keep-alive` — refreshes a lease to prevent it from expiring
-- `lease revoke` — immediately expires a lease and deletes its keys
+Here are definitions of the commands and flags used in the examples below.
 
-For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+| Term | Definition |
+| --- | --- |
+| `--endpoints` | A comma-delimited list of machine addresses in the cluster, for example `localhost:2379`. |
+| `lease grant` | Creates a new lease with a TTL, given in seconds. Returns a lease ID. |
+| `put` | Writes a value to a key. |
+| `value` | The value written to the key in the examples below. |
+| `--lease` | Attaches a key to a lease, so the key is deleted when the lease expires. |
+| `get` | Reads the value of a key. |
+| `lease keep-alive` | Refreshes a lease so that it does not expire. |
+| `lease revoke` | Expires a lease immediately, deleting all keys attached to it. |
+
+For more information on leases, see
+[Interacting with etcd: Grant leases](https://etcd.io/docs/v3.6/dev-guide/interacting_v3/#grant-leases).
 
 ## Grant a lease
 
+![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+
 Grant a lease with a TTL of 300 seconds:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
 ```
 
-Attach a key to the lease so it is automatically deleted when the lease expires:
+Attach a key to the lease, so that the key is deleted when the lease expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
 ```
 
 Keep the lease alive by refreshing it before it expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
 ```
 
 ## Revoke a lease
 
-Revoke the lease immediately, which also deletes all keys attached to it:
+Revoke the lease immediately. This also deletes every key attached to it:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
 ```
 
-After revocation (or after the TTL expires), the key is no longer accessible:
+After the lease is revoked, or after its TTL expires, the attached key is gone:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS get sample
 # (empty response)
 ```

--- a/content/en/docs/v3.7/tasks/developer/how-to-create-lease.md
+++ b/content/en/docs/v3.7/tasks/developer/how-to-create-lease.md
@@ -1,23 +1,57 @@
 ---
-title: How to create lease
-description: Guide to creating a lease in etcd
+title: Granting and revoking leases
+description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
-`lease` to write with TTL:
+## Prerequisites
 
+- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
+- `etcdctl` installed and configured
 
-![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+The following variables are used in this guide:
 
-```shell
+- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
+- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
+- `put --lease` — attaches a key to a lease so it expires with it
+- `lease keep-alive` — refreshes a lease to prevent it from expiring
+- `lease revoke` — immediately expires a lease and deletes its keys
+
+For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+
+## Grant a lease
+
+Grant a lease with a TTL of 300 seconds:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
+```
 
+Attach a key to the lease so it is automatically deleted when the lease expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
+```
 
+Keep the lease alive by refreshing it before it expires:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
+```
+
+## Revoke a lease
+
+Revoke the lease immediately, which also deletes all keys attached to it:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
-# or after 300 seconds
+```
+
+After revocation (or after the TTL expires), the key is no longer accessible:
+
+```bash
 etcdctl --endpoints=$ENDPOINTS get sample
+# (empty response)
 ```

--- a/content/en/docs/v3.7/tasks/developer/how-to-create-lease.md
+++ b/content/en/docs/v3.7/tasks/developer/how-to-create-lease.md
@@ -4,54 +4,67 @@ description: Guide to granting and revoking leases in etcd
 weight: 700
 ---
 
+A lease is a time-to-live (TTL) that keys can be attached to. When the lease
+expires or is revoked, etcd automatically deletes every key attached to it.
+
 ## Prerequisites
 
-- A running etcd cluster (see [getting started](/docs/v3.5/quickstart/))
-- `etcdctl` installed and configured
+* Install [`etcd` and `etcdctl`](https://etcd.io/docs/v3.7/install/).
+* A running `etcd` cluster.
 
-The following variables are used in this guide:
+## Terminology
 
-- `$ENDPOINTS` — the etcd endpoint(s), e.g. `localhost:2379`
-- `lease grant` — creates a new lease with a TTL (time-to-live) in seconds
-- `put --lease` — attaches a key to a lease so it expires with it
-- `lease keep-alive` — refreshes a lease to prevent it from expiring
-- `lease revoke` — immediately expires a lease and deletes its keys
+Here are definitions of the commands and flags used in the examples below.
 
-For more information on leases, see [Interacting with etcd: Grant leases](/docs/v3.5/dev-guide/interacting_v3/#grant-leases).
+| Term | Definition |
+| --- | --- |
+| `--endpoints` | A comma-delimited list of machine addresses in the cluster, for example `localhost:2379`. |
+| `lease grant` | Creates a new lease with a TTL, given in seconds. Returns a lease ID. |
+| `put` | Writes a value to a key. |
+| `value` | The value written to the key in the examples below. |
+| `--lease` | Attaches a key to a lease, so the key is deleted when the lease expires. |
+| `get` | Reads the value of a key. |
+| `lease keep-alive` | Refreshes a lease so that it does not expire. |
+| `lease revoke` | Expires a lease immediately, deleting all keys attached to it. |
+
+For more information on leases, see
+[Interacting with etcd: Grant leases](https://etcd.io/docs/v3.7/dev-guide/interacting_v3/#grant-leases).
 
 ## Grant a lease
 
+![07_etcdctl_lease_2016050501](https://storage.googleapis.com/etcd/demo/07_etcdctl_lease_2016050501.gif)
+
 Grant a lease with a TTL of 300 seconds:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease grant 300
 # lease 2be7547fbc6a5afa granted with TTL(300s)
 ```
 
-Attach a key to the lease so it is automatically deleted when the lease expires:
+Attach a key to the lease, so that the key is deleted when the lease expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS put sample value --lease=2be7547fbc6a5afa
 etcdctl --endpoints=$ENDPOINTS get sample
 ```
 
 Keep the lease alive by refreshing it before it expires:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease keep-alive 2be7547fbc6a5afa
 ```
 
 ## Revoke a lease
 
-Revoke the lease immediately, which also deletes all keys attached to it:
+Revoke the lease immediately. This also deletes every key attached to it:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS lease revoke 2be7547fbc6a5afa
 ```
 
-After revocation (or after the TTL expires), the key is no longer accessible:
+After the lease is revoked, or after its TTL expires, the attached key is gone:
 
-```bash
+```shell
 etcdctl --endpoints=$ENDPOINTS get sample
 # (empty response)
 ```


### PR DESCRIPTION
Revises the lease tutorial across v3.5, v3.6, and v3.7 per #793.

Changes:
- Retitles page to "Granting and revoking leases"
- Adds Prerequisites section with required tools and variable definitions
- Adds links to the dev guide for more context
- Adds dedicated "Revoke a lease" section with code sample
- Adds "Grant a lease" section header for clarity

Fixes #793