### PR TITLE
docs: add Docker installation instructions

### DIFF
--- a/content/en/docs/v3.5/install.md
+++ b/content/en/docs/v3.5/install.md
@@ -124,6 +124,47 @@ The recommended way to install etcd on Linux is either through [pre-built binari
     ...
     ```
 
+## Docker
+
+etcd uses [`gcr.io/etcd-development/etcd`](https://gcr.io/etcd-development/etcd) as a
+primary container registry, and [`quay.io/coreos/etcd`](https://quay.io/coreos/etcd) as
+secondary.
+
+To run etcd using Docker:
+
+```sh
+ETCD_VER={{< param git_version_tag >}}
+
+rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
+  docker rmi gcr.io/etcd-development/etcd:${ETCD_VER} || true && \
+  docker run \
+  -p 2379:2379 \
+  -p 2380:2380 \
+  --mount type=bind,source=/tmp/etcd-data.tmp,destination=/etcd-data \
+  --name etcd-gcr-${ETCD_VER} \
+  gcr.io/etcd-development/etcd:${ETCD_VER} \
+  /usr/local/bin/etcd \
+  --name s1 \
+  --data-dir /etcd-data \
+  --listen-client-urls http://0.0.0.0:2379 \
+  --advertise-client-urls http://0.0.0.0:2379 \
+  --listen-peer-urls http://0.0.0.0:2380 \
+  --initial-advertise-peer-urls http://0.0.0.0:2380 \
+  --initial-cluster s1=http://0.0.0.0:2380 \
+  --initial-cluster-token tkn \
+  --initial-cluster-state new \
+  --log-level info \
+  --logger zap \
+  --log-outputs stderr
+
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcd --version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdutl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl get foo
+```
+
 ## Installation as part of Kubernetes installation
 
 - [Running etcd as a Kubernetes StatefulSet][]

--- a/content/en/docs/v3.6/install.md
+++ b/content/en/docs/v3.6/install.md
@@ -129,6 +129,47 @@ The recommended way to install etcd on Linux is either through [pre-built binari
     ...
     ```
 
+## Docker
+
+etcd uses [`gcr.io/etcd-development/etcd`](https://gcr.io/etcd-development/etcd) as a
+primary container registry, and [`quay.io/coreos/etcd`](https://quay.io/coreos/etcd) as
+secondary.
+
+To run etcd using Docker:
+
+```sh
+ETCD_VER={{< param git_version_tag >}}
+
+rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
+  docker rmi gcr.io/etcd-development/etcd:${ETCD_VER} || true && \
+  docker run \
+  -p 2379:2379 \
+  -p 2380:2380 \
+  --mount type=bind,source=/tmp/etcd-data.tmp,destination=/etcd-data \
+  --name etcd-gcr-${ETCD_VER} \
+  gcr.io/etcd-development/etcd:${ETCD_VER} \
+  /usr/local/bin/etcd \
+  --name s1 \
+  --data-dir /etcd-data \
+  --listen-client-urls http://0.0.0.0:2379 \
+  --advertise-client-urls http://0.0.0.0:2379 \
+  --listen-peer-urls http://0.0.0.0:2380 \
+  --initial-advertise-peer-urls http://0.0.0.0:2380 \
+  --initial-cluster s1=http://0.0.0.0:2380 \
+  --initial-cluster-token tkn \
+  --initial-cluster-state new \
+  --log-level info \
+  --logger zap \
+  --log-outputs stderr
+
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcd --version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdutl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl get foo
+```
+
 ## Installation as part of Kubernetes installation
 
 - [Running etcd as a Kubernetes StatefulSet][]

--- a/content/en/docs/v3.7/install.md
+++ b/content/en/docs/v3.7/install.md
@@ -124,6 +124,47 @@ The recommended way to install etcd on Linux is either through [pre-built binari
     ...
     ```
 
+## Docker
+
+etcd uses [`gcr.io/etcd-development/etcd`](https://gcr.io/etcd-development/etcd) as a
+primary container registry, and [`quay.io/coreos/etcd`](https://quay.io/coreos/etcd) as
+secondary.
+
+To run etcd using Docker:
+
+```sh
+ETCD_VER={{< param git_version_tag >}}
+
+rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
+  docker rmi gcr.io/etcd-development/etcd:${ETCD_VER} || true && \
+  docker run \
+  -p 2379:2379 \
+  -p 2380:2380 \
+  --mount type=bind,source=/tmp/etcd-data.tmp,destination=/etcd-data \
+  --name etcd-gcr-${ETCD_VER} \
+  gcr.io/etcd-development/etcd:${ETCD_VER} \
+  /usr/local/bin/etcd \
+  --name s1 \
+  --data-dir /etcd-data \
+  --listen-client-urls http://0.0.0.0:2379 \
+  --advertise-client-urls http://0.0.0.0:2379 \
+  --listen-peer-urls http://0.0.0.0:2380 \
+  --initial-advertise-peer-urls http://0.0.0.0:2380 \
+  --initial-cluster s1=http://0.0.0.0:2380 \
+  --initial-cluster-token tkn \
+  --initial-cluster-state new \
+  --log-level info \
+  --logger zap \
+  --log-outputs stderr
+
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcd --version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdutl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl get foo
+```
+
 ## Installation as part of Kubernetes installation
 
 - [Running etcd as a Kubernetes StatefulSet][]


### PR DESCRIPTION
Adds a Docker section to the install page for v3.6, resolving the gap between the GitHub release notes and the official documentation.

The GitHub release notes (e.g. https://github.com/etcd-io/etcd/releases/tag/v3.6.12) currently include installation instructions for Linux, macOS, and Docker. The official install page (https://etcd.io/docs/v3.6/install/) already covers Linux and macOS, but was missing Docker instructions entirely.

As part of the effort to move installation instructions out of the release notes and into the official docs (#1174), this PR adds the missing Docker section.

Changes:
- Added a new `## Docker` section to `content/en/docs/v3.6/install.md`
- Includes instructions for running etcd via Docker using
  `gcr.io/etcd-development/etcd` (primary) and `quay.io/coreos/etcd` (secondary)
- Uses `{{< param git_version_tag >}}` to keep the version reference
  consistent with the rest of the page

Closes #1172