### PR TITLE
Update 3.5, 3.6 and 3.7 docs to cover the new option `--v2-deprecation=write-only-skip-check`

### DIFF
--- a/content/en/docs/v3.5/op-guide/configuration.md
+++ b/content/en/docs/v3.5/op-guide/configuration.md
@@ -127,10 +127,12 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Phase of v2store deprecation. Allows to opt-in for higher compatibility mode.
   Supported values:
     'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)
-    'write-only'             // Custom v2 state is not allowed (planned default in v3.6)
-    'write-only-drop-data'   // Custom v2 state will get DELETED !
-    'gone'                   // v2store is not maintained any longer. (planned default in v3.7)
+    'write-only'             // Custom v2 state is not allowed (default in v3.6 and v3.7)
+    'write-only-skip-check'  // Custom v2 state is not supported and, if present, will be ignored (available in v3.5.32+, v3.6.13+, and v3.7.0+). Use this option at your own risk.
+    'write-only-drop-data'   // Custom v2 state will get DELETED ! (planned default in v3.8)
+    'gone'                   // v2store is not maintained any longer.
 ```
+
 ### Security
 
 ```nocode

--- a/content/en/docs/v3.6/op-guide/configuration.md
+++ b/content/en/docs/v3.6/op-guide/configuration.md
@@ -128,9 +128,10 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Phase of v2store deprecation. Allows to opt-in for higher compatibility mode.
   Supported values:
     'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)
-    'write-only'             // Custom v2 state is not allowed (planned default in v3.6)
-    'write-only-drop-data'   // Custom v2 state will get DELETED !
-    'gone'                   // v2store is not maintained any longer. (planned default in v3.7)
+    'write-only'             // Custom v2 state is not allowed (default in v3.6 and v3.7)
+    'write-only-skip-check'  // Custom v2 state is not supported and, if present, will be ignored (available in v3.5.32+, v3.6.13+, and v3.7.0+). Use this option at your own risk.
+    'write-only-drop-data'   // Custom v2 state will get DELETED ! (planned default in v3.8)
+    'gone'                   // v2store is not maintained any longer.
 ```
 
 ### Security

--- a/content/en/docs/v3.7/op-guide/configuration.md
+++ b/content/en/docs/v3.7/op-guide/configuration.md
@@ -130,9 +130,10 @@ The list of flags provided below may not be up-to-date due to ongoing developmen
   Phase of v2store deprecation. Allows to opt-in for higher compatibility mode.
   Supported values:
     'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)
-    'write-only'             // Custom v2 state is not allowed (planned default in v3.6)
-    'write-only-drop-data'   // Custom v2 state will get DELETED !
-    'gone'                   // v2store is not maintained any longer. (planned default in v3.7)
+    'write-only'             // Custom v2 state is not allowed (default in v3.6 and v3.7)
+    'write-only-skip-check'  // Custom v2 state is not supported and, if present, will be ignored (available in v3.5.32+, v3.6.13+, and v3.7.0+). Use this option at your own risk.
+    'write-only-drop-data'   // Custom v2 state will get DELETED ! (planned default in v3.8)
+    'gone'                   // v2store is not maintained any longer.
 ```
 
 ### Security


### PR DESCRIPTION
Link to: 
- 3.5: https://github.com/etcd-io/etcd/pull/21897
- 3.6: https://github.com/etcd-io/etcd/pull/21850
- 3.7: https://github.com/etcd-io/etcd/pull/21848

cc @ivanvc @jberkus @spzala 