### PR TITLE
Remove all references to play.etcd.io

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -2,7 +2,6 @@ DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreURLs:
-  - "^http://play.etcd.io.*"
   # Manually verified external links below this point
   - "^https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations"
   - "^https://www.consul.io/docs/dynamic-app-config/sessions"

--- a/config.yaml
+++ b/config.yaml
@@ -211,5 +211,3 @@ menu:
       pageref: /blog/
     - name: Install
       url: /docs/latest/install/
-    - name: Play
-      url: http://play.etcd.io/play


### PR DESCRIPTION
Resolves #1166

- Remove Play menu item from config.yaml that linked to http://play.etcd.io/play
- Remove play.etcd.io URL pattern from .htmltest.yml ignore list

As per the decision to stop maintaining play.etcd.io, all active references have been removed from the website. References in old blog posts and documentation before v3.5 were not modified per the issue requirements.