### PR TITLE
docs: describe current TLS behavior on the security page

### DIFF
--- a/content/en/docs/v3.5/op-guide/security.md
+++ b/content/en/docs/v3.5/op-guide/security.md
@@ -241,7 +241,7 @@ $ curl -k https://127.0.0.1:2379/v2/keys/foo -Xput -d value=bar -v
 
 ## Notes for DNS SRV
 
-Since v3.1.0 (except v3.2.9), discovery SRV bootstrapping authenticates `ServerName` with a root domain name from `--discovery-srv` flag. This is to avoid man-in-the-middle cert attacks, by requiring a certificate to have matching root domain name in its Subject Alternative Name (SAN) field. For instance, `etcd --discovery-srv=etcd.local` will only authenticate peers/clients when the provided certs have root domain `etcd.local` as an entry in Subject Alternative Name (SAN) field
+When bootstrapping a cluster with DNS SRV discovery, if the peer URLs use HTTPS and `--peer-trusted-ca-file` is not set, etcd sets the peer TLS `ServerName` to the root domain name given by the `--discovery-srv` flag. This prevents man-in-the-middle certificate attacks by requiring each peer certificate to carry that root domain name in its Subject Alternative Name (SAN) field. For example, with `--discovery-srv=etcd.local`, each peer certificate must list `etcd.local` in its SAN field.
 
 ## Notes for etcd proxy
 
@@ -253,147 +253,31 @@ When client authentication is enabled for an etcd member, the administrator must
 
 ## Notes for TLS authentication
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md#v320-2017-06-09), [TLS certificates get reloaded on every client connection](https://github.com/etcd-io/etcd/pull/7829). This is useful when replacing expiry certs without stopping etcd servers; it can be done by overwriting old certs with new ones. Refreshing certs for every connection should not have too much overhead, but can be improved in the future, with caching layer. Example tests can be found [here](https://github.com/etcd-io/etcd/blob/b041ce5d514a4b4aaeefbffb008f0c7570a18986/integration/v3_grpc_test.go#L1601-L1757).
+### Certificate reload
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md#v320-2017-06-09), [server denies incoming peer certs with wrong IP `SAN`](https://github.com/etcd-io/etcd/pull/7687). For instance, if peer cert contains any IP addresses in Subject Alternative Name (SAN) field, server authenticates a peer only when the remote IP address matches one of those IP addresses. This is to prevent unauthorized endpoints from joining the cluster. For example, peer B's CSR (with `cfssl`) is:
+etcd reloads its TLS certificates on every new connection, so expiring certificates can be replaced without restarting the server: write the new certificate and key files and rename them into place, and subsequent connections use them. Reload also works for certificates whose Subject Alternative Name (SAN) field contains only IP addresses and no domain names.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local",
-    "10.138.0.27"
-  ],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "CA",
-      "ST": "San Francisco"
-    }
-  ]
-}
-```
+### Subject Alternative Name (SAN) verification
 
-when peer B's actual IP address is `10.138.0.2`, not `10.138.0.27`. When peer B tries to join the cluster, peer A will reject B with the error `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`, because B's remote IP address does not match the one in Subject Alternative Name (SAN) field.
+When a peer presents a certificate, the receiving member authenticates it against the certificate's Subject Alternative Name (SAN) field and the remote IP address of the connection. This prevents unauthorized endpoints from joining the cluster:
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md#v320-2017-06-09), [server resolves TLS `DNSNames` when checking `SAN`](https://github.com/etcd-io/etcd/pull/7767). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server authenticates a peer only when forward-lookups (`dig b.com`) on those DNS names have matching IP with the remote IP address. For example, peer B's CSR (with `cfssl`) is:
+- If the SAN field contains no IP addresses and no DNS names, no SAN-based restriction is applied.
+- If the SAN field contains IP addresses and the remote IP matches one of them, the connection is accepted without any further DNS checks.
+- If the SAN field contains only IP addresses and none matches the remote IP, the connection is rejected — for example, `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`.
+- If the SAN field contains DNS names, etcd performs a reverse lookup of the remote IP and accepts the connection when a resulting name matches a SAN entry, either exactly or through a wildcard such as `*.example.default.svc`. Otherwise it performs a forward lookup of each non-wildcard DNS name in the SAN and accepts the connection when a resolved address equals the remote IP. If no lookup matches, the connection is rejected — for example, `tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "b.com"
-  ],
-```
+This SAN check applies to peer connections; client connections instead rely on standard X.509 chain verification.
 
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A looks up the incoming host `b.com` to get the list of IP addresses (e.g. `dig b.com`). And rejects B if the list does not contain the IP `10.138.0.2`, with the error `tls: 10.138.0.2 does not match any of DNSNames ["b.com"]`.
+### Common Name and hostname authentication
 
-Since [v3.2.2](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md#v322-2017-07-07), [server accepts connections if IP matches, without checking DNS entries](https://github.com/etcd-io/etcd/pull/8223). For instance, if peer cert contains IP addresses and DNS names in Subject Alternative Name (SAN) field, and the remote IP address matches one of those IP addresses, server just accepts connection without further checking the DNS names. For example, peer B's CSR (with `cfssl`) is:
+When cluster members share a certificate authority — for example, during Kubernetes TLS bootstrapping, where dynamic certificates are issued to etcd members and to other system components such as the API server and kubelet — etcd can further restrict which certificates are accepted by Common Name (CN) or hostname:
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "invalid.domain",
-    "10.138.0.2"
-  ],
-```
+- `--peer-cert-allowed-cn` accepts a peer only when the certificate's Common Name (CN) exactly matches one of the configured values. The comparison is an exact string match; wildcards and prefix matching are not supported.
+- `--peer-cert-allowed-hostname` (for peer certificates) and `--client-cert-allowed-hostname` (for client certificates) match against the certificate's SAN using Go's `x509.Certificate.VerifyHostname()`, which supports both exact hostnames and wildcard entries such as `*.example.com`.
 
-when peer B's remote IP address is `10.138.0.2` and `invalid.domain` is a invalid host. When peer B tries to join the cluster, peer A successfully authenticates B, since Subject Alternative Name (SAN) field has a valid matching IP address. See [issue#8206](https://github.com/etcd-io/etcd/issues/8206) for more detail.
+`--peer-cert-allowed-cn` and `--peer-cert-allowed-hostname` are mutually exclusive; etcd refuses to start if both are set. `--client-cert-allowed-hostname` is independent and can be combined with either peer flag.
 
-Since [v3.2.5](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md#v325-2017-08-04), [server supports reverse-lookup on wildcard DNS `SAN`](https://github.com/etcd-io/etcd/pull/8281). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server first reverse-lookups the remote IP address to get a list of names mapping to that address (e.g. `nslookup IPADDR`). Then accepts the connection if those names have a matching name with peer cert's DNS names (either by exact or wildcard match). If none is matched, server forward-lookups each DNS entry in peer cert (e.g. look up `example.default.svc` when the entry is `*.example.default.svc`), and accepts connection only when the host's resolved addresses have the matching IP address with the peer's remote IP address. For example, peer B's CSR (with `cfssl`) is:
-
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local"
-  ],
-```
-
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A reverse-lookup the IP `10.138.0.2` to get the list of host names. And either exact or wildcard match the host names with peer B's cert DNS names in Subject Alternative Name (SAN) field. If none of reverse/forward lookups worked, it returns an error `"tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`. See [issue#8268](https://github.com/etcd-io/etcd/issues/8268) for more detail.
-
-[v3.3.0](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md) adds [`etcd --peer-cert-allowed-cn`](https://github.com/etcd-io/etcd/pull/8616) flag to support [CN(Common Name)-based auth for inter-peer connections](https://github.com/etcd-io/etcd/issues/8262). Kubernetes TLS bootstrapping involves generating dynamic certificates for etcd members and other system components (e.g. API server, kubelet, etc.). Maintaining different CAs for each component provides tighter access control to etcd cluster but often tedious. When `--peer-cert-allowed-cn` flag is specified, node can only join with matching common name even with shared CAs. The match is an exact string comparison against the certificate's Common Name (CN) field — no wildcards or prefix matching is supported. For hostname-based filtering using --peer-cert-allowed-hostname or --client-cert-allowed-hostname, the match uses Go's x509.Certificate.VerifyHostname(), which supports both exact hostnames and wildcard entries (e.g. *.example.com). For example, each member in 3-node cluster is set up with CSRs (with `cfssl`) as below:
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m1.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m2.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m3.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-Then only peers with matching common names will be authenticated if `--peer-cert-allowed-cn etcd.local` is given. And nodes with different CNs in CSRs or different `--peer-cert-allowed-cn` will be rejected:
-
-```bash
-$ etcd --peer-cert-allowed-cn m1.etcd.local
-
-I | embed: rejected connection from "127.0.0.1:48044" (error "CommonName authentication failed", ServerName "m1.etcd.local")
-I | embed: rejected connection from "127.0.0.1:55702" (error "remote error: tls: bad certificate", ServerName "m3.etcd.local")
-```
-
-Each process should be started with:
-
-```bash
-etcd --peer-cert-allowed-cn etcd.local
-
-I | pkg/netutil: resolving m3.etcd.local:32380 to 127.0.0.1:32380
-I | pkg/netutil: resolving m2.etcd.local:22380 to 127.0.0.1:22380
-I | pkg/netutil: resolving m1.etcd.local:2380 to 127.0.0.1:2380
-I | etcdserver: published {Name:m3 ClientURLs:[https://m3.etcd.local:32379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m1 ClientURLs:[https://m1.etcd.local:2379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m2 ClientURLs:[https://m2.etcd.local:22379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | embed: serving client requests on 127.0.0.1:32379
-I | embed: serving client requests on 127.0.0.1:22379
-I | embed: serving client requests on 127.0.0.1:2379
-```
-
-[v3.2.19](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md) and [v3.3.4](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md) fixes TLS reload when [certificate SAN field only includes IP addresses but no domain names](https://github.com/etcd-io/etcd/issues/9541). For example, a member is set up with CSRs (with `cfssl`) as below:
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "127.0.0.1"
-  ],
-```
-
-In Go, server calls `(*tls.Config).GetCertificate` for TLS reload if and only if server's `(*tls.Config).Certificates` field is not empty, or `(*tls.ClientHelloInfo).ServerName` is not empty with a valid SNI from the client. Previously, etcd always populates `(*tls.Config).Certificates` on the initial client TLS handshake, as non-empty. Thus, client was always expected to supply a matching SNI in order to pass the TLS verification and to trigger `(*tls.Config).GetCertificate` to reload TLS assets.
-
-However, a certificate whose SAN field does [not include any domain names but only IP addresses](https://github.com/etcd-io/etcd/issues/9541) would request `*tls.ClientHelloInfo` with an empty `ServerName` field, thus failing to trigger the TLS reload on initial TLS handshake; this becomes a problem when expired certificates need to be replaced online.
-
-Now, `(*tls.Config).Certificates` is created empty on initial TLS client handshake, first to trigger `(*tls.Config).GetCertificate`, and then to populate rest of the certificates on every new TLS connection, even when client SNI is empty (e.g. cert only includes IPs).
+For example, in a three-node cluster whose members are all issued certificates with the Common Name `etcd.local`, starting every member with `--peer-cert-allowed-cn etcd.local` lets the members authenticate one another, while a node that presents a different Common Name is rejected with a `client certificate authentication failed` error.
 
 ## Notes for Host Whitelist
 

--- a/content/en/docs/v3.6/op-guide/security.md
+++ b/content/en/docs/v3.6/op-guide/security.md
@@ -358,7 +358,7 @@ If all endpoints return healthy, your cluster is now fully secured with TLS!
 
 ## Notes for DNS SRV
 
-Since v3.1.0 (except v3.2.9), discovery SRV bootstrapping authenticates `ServerName` with a root domain name from `--discovery-srv` flag. This is to avoid man-in-the-middle cert attacks, by requiring a certificate to have matching root domain name in its Subject Alternative Name (SAN) field. For instance, `etcd --discovery-srv=etcd.local` will only authenticate peers/clients when the provided certs have root domain `etcd.local` as an entry in Subject Alternative Name (SAN) field
+When bootstrapping a cluster with DNS SRV discovery, if the peer URLs use HTTPS and `--peer-trusted-ca-file` is not set, etcd sets the peer TLS `ServerName` to the root domain name given by the `--discovery-srv` flag. This prevents man-in-the-middle certificate attacks by requiring each peer certificate to carry that root domain name in its Subject Alternative Name (SAN) field. For example, with `--discovery-srv=etcd.local`, each peer certificate must list `etcd.local` in its SAN field.
 
 ## Notes for etcd proxy
 
@@ -370,147 +370,31 @@ When client authentication is enabled for an etcd member, the administrator must
 
 ## Notes for TLS authentication
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [TLS certificates get reloaded on every client connection](https://github.com/etcd-io/etcd/pull/7829). This is useful when replacing expiry certs without stopping etcd servers; it can be done by overwriting old certs with new ones. Refreshing certs for every connection should not have too much overhead, but can be improved in the future, with caching layer. Example tests can be found [here](https://github.com/etcd-io/etcd/blob/b041ce5d514a4b4aaeefbffb008f0c7570a18986/integration/v3_grpc_test.go#L1601-L1757).
+### Certificate reload
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [server denies incoming peer certs with wrong IP `SAN`](https://github.com/etcd-io/etcd/pull/7687). For instance, if peer cert contains any IP addresses in Subject Alternative Name (SAN) field, server authenticates a peer only when the remote IP address matches one of those IP addresses. This is to prevent unauthorized endpoints from joining the cluster. For example, peer B's CSR (with `cfssl`) is:
+etcd reloads its TLS certificates on every new connection, so expiring certificates can be replaced without restarting the server: write the new certificate and key files and rename them into place, and subsequent connections use them. Reload also works for certificates whose Subject Alternative Name (SAN) field contains only IP addresses and no domain names.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local",
-    "10.138.0.27"
-  ],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "CA",
-      "ST": "San Francisco"
-    }
-  ]
-}
-```
+### Subject Alternative Name (SAN) verification
 
-when peer B's actual IP address is `10.138.0.2`, not `10.138.0.27`. When peer B tries to join the cluster, peer A will reject B with the error `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`, because B's remote IP address does not match the one in Subject Alternative Name (SAN) field.
+When a peer presents a certificate, the receiving member authenticates it against the certificate's Subject Alternative Name (SAN) field and the remote IP address of the connection. This prevents unauthorized endpoints from joining the cluster:
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [server resolves TLS `DNSNames` when checking `SAN`](https://github.com/etcd-io/etcd/pull/7767). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server authenticates a peer only when forward-lookups (`dig b.com`) on those DNS names have matching IP with the remote IP address. For example, peer B's CSR (with `cfssl`) is:
+- If the SAN field contains no IP addresses and no DNS names, no SAN-based restriction is applied.
+- If the SAN field contains IP addresses and the remote IP matches one of them, the connection is accepted without any further DNS checks.
+- If the SAN field contains only IP addresses and none matches the remote IP, the connection is rejected — for example, `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`.
+- If the SAN field contains DNS names, etcd performs a reverse lookup of the remote IP and accepts the connection when a resulting name matches a SAN entry, either exactly or through a wildcard such as `*.example.default.svc`. Otherwise it performs a forward lookup of each non-wildcard DNS name in the SAN and accepts the connection when a resolved address equals the remote IP. If no lookup matches, the connection is rejected — for example, `tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "b.com"
-  ],
-```
+This SAN check applies to peer connections; client connections instead rely on standard X.509 chain verification.
 
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A looks up the incoming host `b.com` to get the list of IP addresses (e.g. `dig b.com`). And rejects B if the list does not contain the IP `10.138.0.2`, with the error `tls: 10.138.0.2 does not match any of DNSNames ["b.com"]`.
+### Common Name and hostname authentication
 
-Since [v3.2.2](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v322-2017-07-07), [server accepts connections if IP matches, without checking DNS entries](https://github.com/etcd-io/etcd/pull/8223). For instance, if peer cert contains IP addresses and DNS names in Subject Alternative Name (SAN) field, and the remote IP address matches one of those IP addresses, server just accepts connection without further checking the DNS names. For example, peer B's CSR (with `cfssl`) is:
+When cluster members share a certificate authority — for example, during Kubernetes TLS bootstrapping, where dynamic certificates are issued to etcd members and to other system components such as the API server and kubelet — etcd can further restrict which certificates are accepted by Common Name (CN) or hostname:
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "invalid.domain",
-    "10.138.0.2"
-  ],
-```
+- `--peer-cert-allowed-cn` accepts a peer only when the certificate's Common Name (CN) exactly matches one of the configured values. The comparison is an exact string match; wildcards and prefix matching are not supported.
+- `--peer-cert-allowed-hostname` (for peer certificates) and `--client-cert-allowed-hostname` (for client certificates) match against the certificate's SAN using Go's `x509.Certificate.VerifyHostname()`, which supports both exact hostnames and wildcard entries such as `*.example.com`.
 
-when peer B's remote IP address is `10.138.0.2` and `invalid.domain` is a invalid host. When peer B tries to join the cluster, peer A successfully authenticates B, since Subject Alternative Name (SAN) field has a valid matching IP address. See [issue#8206](https://github.com/etcd-io/etcd/issues/8206) for more detail.
+`--peer-cert-allowed-cn` and `--peer-cert-allowed-hostname` are mutually exclusive; etcd refuses to start if both are set. `--client-cert-allowed-hostname` is independent and can be combined with either peer flag.
 
-Since [v3.2.5](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v325-2017-08-04), [server supports reverse-lookup on wildcard DNS `SAN`](https://github.com/etcd-io/etcd/pull/8281). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server first reverse-lookups the remote IP address to get a list of names mapping to that address (e.g. `nslookup IPADDR`). Then accepts the connection if those names have a matching name with peer cert's DNS names (either by exact or wildcard match). If none is matched, server forward-lookups each DNS entry in peer cert (e.g. look up `example.default.svc` when the entry is `*.example.default.svc`), and accepts connection only when the host's resolved addresses have the matching IP address with the peer's remote IP address. For example, peer B's CSR (with `cfssl`) is:
-
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local"
-  ],
-```
-
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A reverse-lookup the IP `10.138.0.2` to get the list of host names. And either exact or wildcard match the host names with peer B's cert DNS names in Subject Alternative Name (SAN) field. If none of reverse/forward lookups worked, it returns an error `"tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`. See [issue#8268](https://github.com/etcd-io/etcd/issues/8268) for more detail.
-
-[v3.3.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.3.md) adds [`etcd --peer-cert-allowed-cn`](https://github.com/etcd-io/etcd/pull/8616) flag to support [CN(Common Name)-based auth for inter-peer connections](https://github.com/etcd-io/etcd/issues/8262). Kubernetes TLS bootstrapping involves generating dynamic certificates for etcd members and other system components (e.g. API server, kubelet, etc.). Maintaining different CAs for each component provides tighter access control to etcd cluster but often tedious. When `--peer-cert-allowed-cn` flag is specified, node can only join with matching common name even with shared CAs. The match is an exact string comparison against the certificate's Common Name (CN) field — no wildcards or prefix matching is supported. For hostname-based filtering using --peer-cert-allowed-hostname or --client-cert-allowed-hostname, the match uses Go's x509.Certificate.VerifyHostname(), which supports both exact hostnames and wildcard entries (e.g. *.example.com). For example, each member in 3-node cluster is set up with CSRs (with `cfssl`) as below:
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m1.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m2.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m3.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-Then only peers with matching common names will be authenticated if `--peer-cert-allowed-cn etcd.local` is given. And nodes with different CNs in CSRs or different `--peer-cert-allowed-cn` will be rejected:
-
-```bash
-$ etcd --peer-cert-allowed-cn m1.etcd.local
-
-I | embed: rejected connection from "127.0.0.1:48044" (error "CommonName authentication failed", ServerName "m1.etcd.local")
-I | embed: rejected connection from "127.0.0.1:55702" (error "remote error: tls: bad certificate", ServerName "m3.etcd.local")
-```
-
-Each process should be started with:
-
-```bash
-etcd --peer-cert-allowed-cn etcd.local
-
-I | pkg/netutil: resolving m3.etcd.local:32380 to 127.0.0.1:32380
-I | pkg/netutil: resolving m2.etcd.local:22380 to 127.0.0.1:22380
-I | pkg/netutil: resolving m1.etcd.local:2380 to 127.0.0.1:2380
-I | etcdserver: published {Name:m3 ClientURLs:[https://m3.etcd.local:32379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m1 ClientURLs:[https://m1.etcd.local:2379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m2 ClientURLs:[https://m2.etcd.local:22379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | embed: serving client requests on 127.0.0.1:32379
-I | embed: serving client requests on 127.0.0.1:22379
-I | embed: serving client requests on 127.0.0.1:2379
-```
-
-[v3.2.19](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md) and [v3.3.4](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.3.md) fixes TLS reload when [certificate SAN field only includes IP addresses but no domain names](https://github.com/etcd-io/etcd/issues/9541). For example, a member is set up with CSRs (with `cfssl`) as below:
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "127.0.0.1"
-  ],
-```
-
-In Go, server calls `(*tls.Config).GetCertificate` for TLS reload if and only if server's `(*tls.Config).Certificates` field is not empty, or `(*tls.ClientHelloInfo).ServerName` is not empty with a valid SNI from the client. Previously, etcd always populates `(*tls.Config).Certificates` on the initial client TLS handshake, as non-empty. Thus, client was always expected to supply a matching SNI in order to pass the TLS verification and to trigger `(*tls.Config).GetCertificate` to reload TLS assets.
-
-However, a certificate whose SAN field does [not include any domain names but only IP addresses](https://github.com/etcd-io/etcd/issues/9541) would request `*tls.ClientHelloInfo` with an empty `ServerName` field, thus failing to trigger the TLS reload on initial TLS handshake; this becomes a problem when expired certificates need to be replaced online.
-
-Now, `(*tls.Config).Certificates` is created empty on initial TLS client handshake, first to trigger `(*tls.Config).GetCertificate`, and then to populate rest of the certificates on every new TLS connection, even when client SNI is empty (e.g. cert only includes IPs).
+For example, in a three-node cluster whose members are all issued certificates with the Common Name `etcd.local`, starting every member with `--peer-cert-allowed-cn etcd.local` lets the members authenticate one another, while a node that presents a different Common Name is rejected with a `client certificate authentication failed` error.
 
 ## Notes for Host Whitelist
 

--- a/content/en/docs/v3.7/op-guide/security.md
+++ b/content/en/docs/v3.7/op-guide/security.md
@@ -267,7 +267,7 @@ $ curl -k https://127.0.0.1:2379/v2/keys/foo -Xput -d value=bar -v
 
 ## Notes for DNS SRV
 
-Since v3.1.0 (except v3.2.9), discovery SRV bootstrapping authenticates `ServerName` with a root domain name from `--discovery-srv` flag. This is to avoid man-in-the-middle cert attacks, by requiring a certificate to have matching root domain name in its Subject Alternative Name (SAN) field. For instance, `etcd --discovery-srv=etcd.local` will only authenticate peers/clients when the provided certs have root domain `etcd.local` as an entry in Subject Alternative Name (SAN) field
+When bootstrapping a cluster with DNS SRV discovery, if the peer URLs use HTTPS and `--peer-trusted-ca-file` is not set, etcd sets the peer TLS `ServerName` to the root domain name given by the `--discovery-srv` flag. This prevents man-in-the-middle certificate attacks by requiring each peer certificate to carry that root domain name in its Subject Alternative Name (SAN) field. For example, with `--discovery-srv=etcd.local`, each peer certificate must list `etcd.local` in its SAN field.
 
 ## Notes for etcd proxy
 
@@ -279,150 +279,31 @@ When client authentication is enabled for an etcd member, the administrator must
 
 ## Notes for TLS authentication
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [TLS certificates get reloaded on every client connection](https://github.com/etcd-io/etcd/pull/7829). This is useful when replacing expiry certs without stopping etcd servers; it can be done by overwriting old certs with new ones. Refreshing certs for every connection should not have too much overhead, but can be improved in the future, with caching layer. Example tests can be found [here](https://github.com/etcd-io/etcd/blob/b041ce5d514a4b4aaeefbffb008f0c7570a18986/integration/v3_grpc_test.go#L1601-L1757).
+### Certificate reload
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [server denies incoming peer certs with wrong IP `SAN`](https://github.com/etcd-io/etcd/pull/7687). For instance, if peer cert contains any IP addresses in Subject Alternative Name (SAN) field, server authenticates a peer only when the remote IP address matches one of those IP addresses. This is to prevent unauthorized endpoints from joining the cluster. For example, peer B's CSR (with `cfssl`) is:
+etcd reloads its TLS certificates on every new connection, so expiring certificates can be replaced without restarting the server: write the new certificate and key files and rename them into place, and subsequent connections use them. Reload also works for certificates whose Subject Alternative Name (SAN) field contains only IP addresses and no domain names.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local",
-    "10.138.0.27"
-  ],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "CA",
-      "ST": "San Francisco"
-    }
-  ]
-}
-```
+### Subject Alternative Name (SAN) verification
 
-when peer B's actual IP address is `10.138.0.2`, not `10.138.0.27`. When peer B tries to join the cluster, peer A will reject B with the error `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`, because B's remote IP address does not match the one in Subject Alternative Name (SAN) field.
+When a peer presents a certificate, the receiving member authenticates it against the certificate's Subject Alternative Name (SAN) field and the remote IP address of the connection. This prevents unauthorized endpoints from joining the cluster:
 
-Since [v3.2.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v320-2017-06-09), [server resolves TLS `DNSNames` when checking `SAN`](https://github.com/etcd-io/etcd/pull/7767). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server authenticates a peer only when forward-lookups (`dig b.com`) on those DNS names have matching IP with the remote IP address. For example, peer B's CSR (with `cfssl`) is:
+- If the SAN field contains no IP addresses and no DNS names, no SAN-based restriction is applied.
+- If the SAN field contains IP addresses and the remote IP matches one of them, the connection is accepted without any further DNS checks.
+- If the SAN field contains only IP addresses and none matches the remote IP, the connection is rejected — for example, `x509: certificate is valid for 10.138.0.27, not 10.138.0.2`.
+- If the SAN field contains DNS names, etcd performs a reverse lookup of the remote IP and accepts the connection when a resulting name matches a SAN entry, either exactly or through a wildcard such as `*.example.default.svc`. Otherwise it performs a forward lookup of each non-wildcard DNS name in the SAN and accepts the connection when a resolved address equals the remote IP. If no lookup matches, the connection is rejected — for example, `tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`.
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "b.com"
-  ],
-```
+This SAN check applies to peer connections; client connections instead rely on standard X.509 chain verification.
 
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A looks up the incoming host `b.com` to get the list of IP addresses (e.g. `dig b.com`). And rejects B if the list does not contain the IP `10.138.0.2`, with the error `tls: 10.138.0.2 does not match any of DNSNames ["b.com"]`.
+### Common Name and hostname authentication
 
-Since [v3.2.2](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v322-2017-07-07), [server accepts connections if IP matches, without checking DNS entries](https://github.com/etcd-io/etcd/pull/8223). For instance, if peer cert contains IP addresses and DNS names in Subject Alternative Name (SAN) field, and the remote IP address matches one of those IP addresses, server just accepts connection without further checking the DNS names. For example, peer B's CSR (with `cfssl`) is:
+When cluster members share a certificate authority — for example, during Kubernetes TLS bootstrapping, where dynamic certificates are issued to etcd members and to other system components such as the API server and kubelet — etcd can further restrict which certificates are accepted by Common Name (CN) or hostname:
 
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "invalid.domain",
-    "10.138.0.2"
-  ],
-```
+- `--peer-cert-allowed-cn` accepts a peer only when the certificate's Common Name (CN) exactly matches one of the configured values. The comparison is an exact string match; wildcards and prefix matching are not supported.
+- `--peer-cert-allowed-hostname` (for peer certificates) and `--client-cert-allowed-hostname` (for client certificates) match against the certificate's SAN using Go's `x509.Certificate.VerifyHostname()`, which supports both exact hostnames and wildcard entries such as `*.example.com`.
 
-when peer B's remote IP address is `10.138.0.2` and `invalid.domain` is a invalid host. When peer B tries to join the cluster, peer A successfully authenticates B, since Subject Alternative Name (SAN) field has a valid matching IP address. See [issue#8206](https://github.com/etcd-io/etcd/issues/8206) for more detail.
+`--peer-cert-allowed-cn` and `--peer-cert-allowed-hostname` are mutually exclusive; etcd refuses to start if both are set. `--client-cert-allowed-hostname` is independent and can be combined with either peer flag.
 
-Since [v3.2.5](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md#v325-2017-08-04), [server supports reverse-lookup on wildcard DNS `SAN`](https://github.com/etcd-io/etcd/pull/8281). For instance, if peer cert contains only DNS names (no IP addresses) in Subject Alternative Name (SAN) field, server first reverse-lookups the remote IP address to get a list of names mapping to that address (e.g. `nslookup IPADDR`). Then accepts the connection if those names have a matching name with peer cert's DNS names (either by exact or wildcard match). If none is matched, server forward-lookups each DNS entry in peer cert (e.g. look up `example.default.svc` when the entry is `*.example.default.svc`), and accepts connection only when the host's resolved addresses have the matching IP address with the peer's remote IP address. For example, peer B's CSR (with `cfssl`) is:
-
-```json
-{
-  "CN": "etcd peer",
-  "hosts": [
-    "*.example.default.svc",
-    "*.example.default.svc.cluster.local"
-  ],
-```
-
-when peer B's remote IP address is `10.138.0.2`. When peer B tries to join the cluster, peer A reverse-lookup the IP `10.138.0.2` to get the list of host names. And either exact or wildcard match the host names with peer B's cert DNS names in Subject Alternative Name (SAN) field. If none of reverse/forward lookups worked, it returns an error `"tls: "10.138.0.2" does not match any of DNSNames ["*.example.default.svc","*.example.default.svc.cluster.local"]`. See [issue#8268](https://github.com/etcd-io/etcd/issues/8268) for more detail.
-
-[v3.3.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.3.md) adds [`etcd --peer-cert-allowed-cn`](https://github.com/etcd-io/etcd/pull/8616) flag to support [CN(Common Name)-based auth for inter-peer connections](https://github.com/etcd-io/etcd/issues/8262). Kubernetes TLS bootstrapping involves generating dynamic certificates for etcd members and other system components (e.g. API server, kubelet, etc.). Maintaining different CAs for each component provides tighter access control to etcd cluster but often tedious. When --peer-cert-allowed-cn flag is specified, node can only join with matching common name even with shared CAs. The match is an exact string comparison against the certificate's Common Name (CN) field — no wildcards or prefix matching is supported. For hostname-based filtering using --peer-cert-allowed-hostname or --client-cert-allowed-hostname, the match uses Go's x509.Certificate.VerifyHostname(), which supports both exact hostnames and wildcard entries (e.g. *.example.com). For example, each member in 3-node cluster is set up with CSRs (with cfssl) as below:
-
-
-
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m1.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m2.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "m3.etcd.local",
-    "127.0.0.1",
-    "localhost"
-  ],
-```
-
-Then only peers with matching common names will be authenticated if `--peer-cert-allowed-cn etcd.local` is given. And nodes with different CNs in CSRs or different `--peer-cert-allowed-cn` will be rejected:
-
-```bash
-$ etcd --peer-cert-allowed-cn m1.etcd.local
-
-I | embed: rejected connection from "127.0.0.1:48044" (error "CommonName authentication failed", ServerName "m1.etcd.local")
-I | embed: rejected connection from "127.0.0.1:55702" (error "remote error: tls: bad certificate", ServerName "m3.etcd.local")
-```
-
-Each process should be started with:
-
-```bash
-etcd --peer-cert-allowed-cn etcd.local
-
-I | pkg/netutil: resolving m3.etcd.local:32380 to 127.0.0.1:32380
-I | pkg/netutil: resolving m2.etcd.local:22380 to 127.0.0.1:22380
-I | pkg/netutil: resolving m1.etcd.local:2380 to 127.0.0.1:2380
-I | etcdserver: published {Name:m3 ClientURLs:[https://m3.etcd.local:32379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m1 ClientURLs:[https://m1.etcd.local:2379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | etcdserver: published {Name:m2 ClientURLs:[https://m2.etcd.local:22379]} to cluster 9db03f09b20de32b
-I | embed: ready to serve client requests
-I | embed: serving client requests on 127.0.0.1:32379
-I | embed: serving client requests on 127.0.0.1:22379
-I | embed: serving client requests on 127.0.0.1:2379
-```
-
-[v3.2.19](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.2.md) and [v3.3.4](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.3.md) fixes TLS reload when [certificate SAN field only includes IP addresses but no domain names](https://github.com/etcd-io/etcd/issues/9541). For example, a member is set up with CSRs (with `cfssl`) as below:
-
-```json
-{
-  "CN": "etcd.local",
-  "hosts": [
-    "127.0.0.1"
-  ],
-```
-
-In Go, server calls `(*tls.Config).GetCertificate` for TLS reload if and only if server's `(*tls.Config).Certificates` field is not empty, or `(*tls.ClientHelloInfo).ServerName` is not empty with a valid SNI from the client. Previously, etcd always populates `(*tls.Config).Certificates` on the initial client TLS handshake, as non-empty. Thus, client was always expected to supply a matching SNI in order to pass the TLS verification and to trigger `(*tls.Config).GetCertificate` to reload TLS assets.
-
-However, a certificate whose SAN field does [not include any domain names but only IP addresses](https://github.com/etcd-io/etcd/issues/9541) would request `*tls.ClientHelloInfo` with an empty `ServerName` field, thus failing to trigger the TLS reload on initial TLS handshake; this becomes a problem when expired certificates need to be replaced online.
-
-Now, `(*tls.Config).Certificates` is created empty on initial TLS client handshake, first to trigger `(*tls.Config).GetCertificate`, and then to populate rest of the certificates on every new TLS connection, even when client SNI is empty (e.g. cert only includes IPs).
+For example, in a three-node cluster whose members are all issued certificates with the Common Name `etcd.local`, starting every member with `--peer-cert-allowed-cn etcd.local` lets the members authenticate one another, while a node that presents a different Common Name is rejected with a `client certificate authentication failed` error.
 
 ## Notes for Host Whitelist
 


### PR DESCRIPTION
## Summary

The "Notes for DNS SRV" and "Notes for TLS authentication" sections of the transport security
page were written as a version-by-version changelog going back to v3.1 (issue #1185). This
rewrites them to describe current behavior.

- Fold the per-release SAN matching paragraphs into one present-tense description: IP-address
  match first, then DNS reverse/forward lookup, with wildcard support.
- Keep the Common Name and hostname matching details (`--peer-cert-allowed-cn`,
  `--peer-cert-allowed-hostname`, `--client-cert-allowed-hostname`), including the exact-match vs
  `VerifyHostname` distinction and the peer flags' mutual exclusivity.
- Correct stale details: the rejection error is `client certificate authentication failed` (not
  `CommonName authentication failed`), and the SAN/remote-address check applies to peer connections.
- Drop the outdated CHANGELOG and PR links.

Applied to the active doc versions v3.5, v3.6, and v3.7 (48 insertions, 399 deletions).

Verified with `npm run build` and `npm run check-links` (htmltest, internal). Technical claims
were checked against the etcd `release-3.6` source and against a live etcd v3.6.13 cluster.

Fixes #1185
