### PR TITLE
docs: fix broken Consul add/remove-servers link in learning/why

### DIFF
--- a/content/en/docs/v3.4/learning/why.md
+++ b/content/en/docs/v3.4/learning/why.md
@@ -86,7 +86,7 @@ For distributed coordination, choosing etcd can help prevent operational headach
 [consul-json]: https://www.consul.io/api-docs#formatted-json-output
 [consul-linread]: https://www.consul.io/api-docs#consistency
 [consul-lock]: https://www.consul.io/commands/lock
-[consul-reconfig]: https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations
+[consul-reconfig]: https://developer.hashicorp.com/consul/tutorials/datacenter-operations/add-remove-servers
 [consul-txn]: https://www.consul.io/api/kv#txn
 [consul-watch]: https://www.consul.io/docs/dynamic-app-config/watches
 [container-linux]: https://coreos.com/why

--- a/content/en/docs/v3.5/learning/why.md
+++ b/content/en/docs/v3.5/learning/why.md
@@ -105,7 +105,7 @@ Note that in the case of etcd keys, it can be locked efficiently because of the 
 [consul-json]: https://www.consul.io/api-docs#formatted-json-output
 [consul-linread]: https://www.consul.io/api-docs#consistency
 [consul-lock]: https://www.consul.io/commands/lock
-[consul-reconfig]: https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations
+[consul-reconfig]: https://developer.hashicorp.com/consul/tutorials/datacenter-operations/add-remove-servers
 [consul-txn]: https://www.consul.io/api/txn
 [consul-watch]: https://www.consul.io/docs/dynamic-app-config/watches
 [container-linux]: https://coreos.com/why

--- a/content/en/docs/v3.6/learning/why.md
+++ b/content/en/docs/v3.6/learning/why.md
@@ -105,7 +105,7 @@ Note that in the case of etcd keys, it can be locked efficiently because of the 
 [consul-json]: https://www.consul.io/api-docs#formatted-json-output
 [consul-linread]: https://www.consul.io/api-docs#consistency
 [consul-lock]: https://www.consul.io/commands/lock
-[consul-reconfig]: https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations
+[consul-reconfig]: https://developer.hashicorp.com/consul/tutorials/datacenter-operations/add-remove-servers
 [consul-txn]: https://www.consul.io/api/kv#txn
 [consul-watch]: https://www.consul.io/docs/dynamic-app-config/watches
 [container-linux]: https://coreos.com/why

--- a/content/en/docs/v3.7/learning/why.md
+++ b/content/en/docs/v3.7/learning/why.md
@@ -105,7 +105,7 @@ Note that in the case of etcd keys, it can be locked efficiently because of the 
 [consul-json]: https://www.consul.io/api-docs#formatted-json-output
 [consul-linread]: https://www.consul.io/api-docs#consistency
 [consul-lock]: https://www.consul.io/commands/lock
-[consul-reconfig]: https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations
+[consul-reconfig]: https://developer.hashicorp.com/consul/tutorials/datacenter-operations/add-remove-servers
 [consul-txn]: https://www.consul.io/api/kv#txn
 [consul-watch]: https://www.consul.io/docs/dynamic-app-config/watches
 [container-linux]: https://coreos.com/why

--- a/content/en/docs/v3.8/learning/why.md
+++ b/content/en/docs/v3.8/learning/why.md
@@ -105,7 +105,7 @@ Note that in the case of etcd keys, it can be locked efficiently because of the 
 [consul-json]: https://www.consul.io/api-docs#formatted-json-output
 [consul-linread]: https://www.consul.io/api-docs#consistency
 [consul-lock]: https://www.consul.io/commands/lock
-[consul-reconfig]: https://learn.hashicorp.com/tutorials/consul/add-remove-servers?in=consul/day-2-operations
+[consul-reconfig]: https://developer.hashicorp.com/consul/tutorials/datacenter-operations/add-remove-servers
 [consul-txn]: https://www.consul.io/api/kv#txn
 [consul-watch]: https://www.consul.io/docs/dynamic-app-config/watches
 [container-linux]: https://coreos.com/why


### PR DESCRIPTION
Several documentation links return HTTP 404. This updates each to its current working location:

- `content/en/docs/v3.4/learning/why.md` (1 link)
- `content/en/docs/v3.5/learning/why.md` (1 link)
- `content/en/docs/v3.6/learning/why.md` (1 link)
- `content/en/docs/v3.7/learning/why.md` (1 link)
- `content/en/docs/v3.8/learning/why.md` (1 link)

Docs-only change. Each replacement URL was verified to return HTTP 200.