### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,5 +1,5 @@
 Contact: https://github.com/etcd-io/etcd/security/advisories/new
-Expires: 2027-07-14T00:00:00.000Z
+Expires: 2031-07-14T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://etcd.io/.well-known/security.txt
 Policy: https://github.com/etcd-io/etcd/blob/main/security/README.md

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/etcd-io/etcd/security/advisories/new
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://etcd.io/.well-known/security.txt
+Policy: https://github.com/etcd-io/etcd/blob/main/security/README.md


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` under `static/` so etcd.io serves one.

## Why
`https://etcd.io/.well-known/security.txt` returns 404. [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) makes `/.well-known/security.txt` the standard, machine-discoverable pointer to a project's security reporting process. etcd already documents one; this makes it discoverable by the convention. Served verbatim from `static/`, with a future `Expires` per §2.5.5. Signed off per DCO.

I used AI assistance to identify this and draft the file; I verified the live 404 myself.