### PR TITLE
release-blog: Etcd Patch Releases: v3.7.1, v3.6.14, and v3.5.33

### DIFF
--- a/content/en/blog/2026/july-23-patch-release.md
+++ b/content/en/blog/2026/july-23-patch-release.md
@@ -1,11 +1,11 @@
 ---
 title: "Etcd Patch Releases: v3.7.1, v3.6.14, and v3.5.33"
 author: "SIG-Etcd Leads"
-date: 2026-08-01
+date: 2026-07-23
 draft: false
 ---
 
-SIG-etcd has released patch updates across all three supported release branches. These releases fix a security vulnerability in the watch API and address several reliability issues in the server, client library, and TLS stack. Users on v3.5, v3.6, and v3.7 should update at the next scheduled maintenance window.
+SIG-etcd has released patch updates across all three supported release branches. These releases fix two security vulnerabilities, several minor security issues, and address several reliability issues in the server, client library, and TLS stack. Users on v3.5, v3.6, and v3.7 should update at the next scheduled maintenance window.
 
 Obtain the updates here:
 
@@ -15,7 +15,7 @@ Obtain the updates here:
 
 Official container images are available from [gcr.io](https://gcr.io/etcd-development/etcd).
 
-## Security fix: watch responses leaked across RBAC key boundaries
+## Security Fix: watch responses leaked across RBAC key boundaries
 
 All three releases fix a vulnerability where a user granted read permission on a single key could receive watch event notifications for every key starting from that key, exposing data beyond their authorized scope.
 
@@ -28,6 +28,8 @@ More information on the vulnerability:
 - CVE-2026-xxx: [CVE Name](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8)
 
 This issue has been rated `TBD`, with CVSS `TBD`.
+
+## Security Fix: 
 
 ## Workarounds
 

--- a/content/en/blog/2026/july-patch-release-v3.7.1.md
+++ b/content/en/blog/2026/july-patch-release-v3.7.1.md
@@ -24,17 +24,20 @@ This vulnerability does not affect etcd as a part of the Kubernetes Control Plan
 Users depending on etcd Auth in this way should update their clusters immediately. Other etcd users can update at the next regularly scheduled maintenance period.
 
 More information on the vulnerability:
-* CVE-2026-xxx: [CVE Name](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8).
 
-This issue has been rated `xx`, with CVSS `CVSS:xxx`.
+- CVE-2026-xxx: [CVE Name](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8)
+
+This issue has been rated `TBD`, with CVSS `TBD`.
 
 ## Workarounds
-TBU
+
+TBD — add workaround details once the advisory is published.
 
 ## Acknowledgements
 
 This vulnerability was reported by members of the etcd community. Our SIG is deeply thankful to:
-- xxx
+
+- TBD — add reporter credit once the advisory is published.
 
 If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
 

--- a/content/en/blog/2026/july-patch-release-v3.7.1.md
+++ b/content/en/blog/2026/july-patch-release-v3.7.1.md
@@ -24,8 +24,17 @@ This vulnerability does not affect etcd as a part of the Kubernetes Control Plan
 Users depending on etcd Auth in this way should update their clusters immediately. Other etcd users can update at the next regularly scheduled maintenance period.
 
 More information on the vulnerability:
+* CVE-2026-xxx: [CVE Name](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8).
 
-- [Watch responses leak data across RBAC key boundaries](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8)
+This issue has been rated `xx`, with CVSS `CVSS:xxx`.
+
+## Workarounds
+TBU
+
+## Acknowledgements
+
+This vulnerability was reported by members of the etcd community. Our SIG is deeply thankful to:
+- xxx
 
 If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
 
@@ -49,6 +58,6 @@ v3.5.33 also bumps `golang.org/x/net` to `v0.56.0` to address [GO-2026-5942](htt
 
 Full changelogs for each release:
 
-- [CHANGELOG-3.7](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.7.md#v371)
-- [CHANGELOG-3.6](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3614)
-- [CHANGELOG-3.5](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3533)
+- [CHANGELOG-3.7.1](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.7.md#v371)
+- [CHANGELOG-3.6.14](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3614)
+- [CHANGELOG-3.5.33](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3533)

--- a/content/en/blog/2026/july-patch-release-v3.7.1.md
+++ b/content/en/blog/2026/july-patch-release-v3.7.1.md
@@ -1,0 +1,54 @@
+---
+title: "Etcd Patch Releases: v3.7.1, v3.6.14, and v3.5.33"
+author: "SIG-Etcd Leads"
+date: 2026-08-01
+draft: false
+---
+
+SIG-etcd has released patch updates across all three supported release branches. These releases fix a security vulnerability in the watch API and address several reliability issues in the server, client library, and TLS stack. Users on v3.5, v3.6, and v3.7 should update at the next scheduled maintenance window.
+
+Obtain the updates here:
+
+- [v3.7.1](https://github.com/etcd-io/etcd/releases/tag/v3.7.1)
+- [v3.6.14](https://github.com/etcd-io/etcd/releases/tag/v3.6.14)
+- [v3.5.33](https://github.com/etcd-io/etcd/releases/tag/v3.5.33)
+
+Official container images are available from [gcr.io](https://gcr.io/etcd-development/etcd).
+
+## Security fix: watch responses leaked across RBAC key boundaries
+
+All three releases fix a vulnerability where a user granted read permission on a single key could receive watch event notifications for every key starting from that key, exposing data beyond their authorized scope.
+
+This vulnerability does not affect etcd as a part of the Kubernetes Control Plane. It only affects etcd clusters with Auth enabled in untrusted or partially trusted environments.
+
+Users depending on etcd Auth in this way should update their clusters immediately. Other etcd users can update at the next regularly scheduled maintenance period.
+
+More information on the vulnerability:
+
+- [Watch responses leak data across RBAC key boundaries](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8)
+
+If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+
+## Reliability fixes shared across all three releases
+
+Beyond the security patch, all three releases include a set of hardening fixes:
+
+- **Unbounded read on peer lease handler**: the HTTP handler for peer lease requests could perform an unbounded `io.ReadAll`, allowing a malicious or misbehaving peer to cause excessive memory use.  This has been fixed by capping the read.
+- **Transaction cost accounting**: the `costTxnReq` function was not accounting for nested `RequestTxn` operations, which could cause request cost estimates to be inaccurate.
+- **HTTP server timeouts**: a `ReadHeaderTimeout` is now set on the client-facing HTTP server, protecting against slow-header attacks that could hold connections open indefinitely.
+- **Client `leaseCache` data race**: a concurrent map iteration over `leaseCache.entries` in `clientv3` was not properly synchronized, which could cause a panic or incorrect behavior under concurrent lease operations.
+- **TLS handshake timeout**: the TLS listener in `client/pkg/v3` now sets a `tlsHandshakeTimeout`, preventing stalled TLS handshakes from holding connections open indefinitely.
+
+v3.7.1 and v3.6.14 additionally fix a `snapshotLimitByte` configuration issue where the snapshot size limit was not initialized to a reasonable default, which could allow snapshots to grow without bound in some configurations.
+
+## Dependency updates in v3.6.14 and v3.5.33
+
+v3.6.14 and v3.5.33 update the Go compiler to [go 1.25.12](https://go.dev/doc/devel/release).
+
+v3.5.33 also bumps `golang.org/x/net` to `v0.56.0` to address [GO-2026-5942](https://pkg.go.dev/vuln/GO-2026-5942) and `golang.org/x/text` to `v0.39.0` to address [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970).
+
+Full changelogs for each release:
+
+- [CHANGELOG-3.7](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.7.md#v371)
+- [CHANGELOG-3.6](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3614)
+- [CHANGELOG-3.5](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3533)

--- a/content/en/blog/2026/mar20-patch-release.md
+++ b/content/en/blog/2026/mar20-patch-release.md
@@ -6,7 +6,7 @@ date: 2026-03-20
 
 SIG-etcd released updates [3.6.9](https://github.com/etcd-io/etcd/releases/tag/v3.6.9), [3.5.28](https://github.com/etcd-io/etcd/releases/tag/v3.5.28), and [3.4.42](https://github.com/etcd-io/etcd/releases/tag/v3.4.42) today.  These patch releases fix several vulnerabilities which allow unauthorized users to bypass authentication or authorization controls that are part of etcd Auth using the gRPC API.
 
-These vulnerabilities do not affect etcd as a part of the Kubernetes Control Plane.  They only affect etcd clusters in other contexts, specifically ones with Auth enabled where it is required for access control in untrusted or partially trusted networks or with untrused users.
+These vulnerabilities do not affect etcd as a part of the Kubernetes Control Plane. They only affect etcd clusters in other contexts, specifically ones with Auth enabled where it is required for access control in untrusted or partially trusted networks or with untrused users.
 
 Users depending on etcd Auth in this way should update their clusters immediately.  Other etcd users can update at the next regularly scheduled maintenance period.
 

--- a/content/en/blog/2026/may-patch-release.md
+++ b/content/en/blog/2026/may-patch-release.md
@@ -29,7 +29,7 @@ If upgrading is not immediately possible, reduce exposure by treating the affect
 
 ## Acknowledgements
 
-This vulnerability was reported by members of the etcd community.  Our SIG is deeply thankful to:
+This vulnerability was reported by members of the etcd community. Our SIG is deeply thankful to:
 
 * Samy Ghannad ([@SamyGhannad](https://github.com/SamyGhannad)) for reporting that read access via `PrevKv` in a `Put` request within etcd transactions bypassed RBAC authorization checks.
 * Benjamin Wang ([@ahrtr](https://github.com/ahrtr)) for further analyzing that lease attachment in a `Put` request within etcd transactions also bypassed RBAC authorization checks.


### PR DESCRIPTION
### What?
- Added release blog for etcd Patch Releases: v3.7.1, v3.6.14, and v3.5.33
- CHANGELOG:
https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.7.md#v371-tbc
https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3614-tbc
https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3533-tbc

### Note
The CVE for Fix [the security issue where a user granted read permission on one key could receive watch responses for every key starting from that key](https://github.com/etcd-io/etcd/security/advisories/GHSA-xg4h-6gfc-h4m8) seems haven't being published yet so I can't see the info.

Doc maintainer may need to update this blog with CVE ID, CVSS, Credit reporter after the CVE being published.

