### PR TITLE
chore: Deprecated v3.4 doc

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -3,7 +3,7 @@ title: v3.4 docs
 cascade:
   version: &vers v3.4
   git_version_tag: v3.4.37
-  is_deprecated: false
+  is_deprecated: true
   exclude_search: true
 linkTitle: *vers
 simple_list: true


### PR DESCRIPTION
What?
- Etcd v3.4 has been announced for EOL in [v3.7-beta.0 blog](https://etcd.io/blog/2026/etcd-370-beta/). This PR turns on `is_deprecated: true` banner for v3.4 doc
- Solve issue: https://github.com/etcd-io/website/issues/1195
- Preview: https://deploy-preview-1202--etcd.netlify.app/docs/v3.4/
<img width="1031" height="201" alt="image" src="https://github.com/user-attachments/assets/19cbc200-ab10-4f37-8402-49d4b9c1d243" />

