### PR TITLE
docs: recommend 3.5.32 before upgrading to 3.6

### DIFF
--- a/content/en/docs/v3.6/upgrades/upgrade_3_6.md
+++ b/content/en/docs/v3.6/upgrades/upgrade_3_6.md
@@ -17,7 +17,7 @@ Before [starting an upgrade](#upgrade-procedure), read through the rest of this 
 
 {{% alert title="Important" color="warning" %}}
 
-Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.26 or later](https://etcd.io/blog/2025/zombie_members_upgrade). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers.
+Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.32 or later](https://etcd.io/blog/2026/july-patch-release/). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers; [3.5.32](https://etcd.io/blog/2026/july-patch-release/) adds `--v2-deprecation=write-only-skip-check` and extends `etcdutl check v2store` to inspect WAL records as well as the v2 snapshot.
 
 {{% /alert %}}
 

--- a/content/en/docs/v3.6/upgrades/upgrade_3_6.md
+++ b/content/en/docs/v3.6/upgrades/upgrade_3_6.md
@@ -17,7 +17,7 @@ Before [starting an upgrade](#upgrade-procedure), read through the rest of this 
 
 {{% alert title="Important" color="warning" %}}
 
-Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.32 or later](https://etcd.io/blog/2026/july-patch-release/). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers; [3.5.32](https://etcd.io/blog/2026/july-patch-release/) adds `--v2-deprecation=write-only-skip-check` and extends `etcdutl check v2store` to inspect WAL records as well as the v2 snapshot.
+Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.32 or later](https://etcd.io/blog/2026/july-patch-release/). Patch releases 3.5.24 through [3.5.32](https://etcd.io/blog/2026/july-patch-release/) fix several potential upgrade blockers including `--v2-deprecation=write-only-skip-check` and `etcdutl check v2store` to inspect WAL records as well as the v2 snapshot.
 
 {{% /alert %}}
 

--- a/content/en/docs/v3.7/upgrades/upgrade_3_6.md
+++ b/content/en/docs/v3.7/upgrades/upgrade_3_6.md
@@ -17,7 +17,7 @@ Before [starting an upgrade](#upgrade-procedure), read through the rest of this 
 
 {{% alert title="Important" color="warning" %}}
 
-Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.26 or later](https://etcd.io/blog/2025/zombie_members_upgrade). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers.
+Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.32 or later](https://etcd.io/blog/2026/july-patch-release/). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers; [3.5.32](https://etcd.io/blog/2026/july-patch-release/) adds `--v2-deprecation=write-only-skip-check` and extends `etcdutl check v2store` to inspect WAL records as well as the v2 snapshot.
 
 {{% /alert %}}
 

--- a/content/en/docs/v3.8/upgrades/upgrade_3_6.md
+++ b/content/en/docs/v3.8/upgrades/upgrade_3_6.md
@@ -17,7 +17,7 @@ Before [starting an upgrade](#upgrade-procedure), read through the rest of this 
 
 {{% alert title="Important" color="warning" %}}
 
-Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.26 or later](https://etcd.io/blog/2025/zombie_members_upgrade). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers.
+Before upgrading to 3.6, make sure that [all of your 3.5 members are updated to 3.5.32 or later](https://etcd.io/blog/2026/july-patch-release/). Patch releases 3.5.24 through 3.5.26 fix several potential upgrade blockers; [3.5.32](https://etcd.io/blog/2026/july-patch-release/) adds `--v2-deprecation=write-only-skip-check` and extends `etcdutl check v2store` to inspect WAL records as well as the v2 snapshot.
 
 {{% /alert %}}
 


### PR DESCRIPTION
The 3.5→3.6 upgrade guide still said patch to 3.5.26. The July release (3.5.32 / 3.6.13) is what brings `write-only-skip-check` and the WAL-aware `etcdutl check v2store`, which the same page already walks through.

Bumped the checklist to 3.5.32 and linked the July blog.

Fixes #1194