### PR TITLE
docs: mark v3.4 documentation as end-of-life

### DIFF
--- a/content/en/docs/v3.4/_index.md
+++ b/content/en/docs/v3.4/_index.md
@@ -3,7 +3,8 @@ title: v3.4 docs
 cascade:
   version: &vers v3.4
   git_version_tag: v3.4.37
-  is_deprecated: false
+  is_deprecated: true
+  page_warning: "is end-of-life (EOL since June 2025) and no longer receives updates."
   exclude_search: true
 linkTitle: *vers
 simple_list: true


### PR DESCRIPTION
v3.4 has been EOL since June 2025 (support dropped once v3.6 was current). Set `is_deprecated` like the older trees so the version banner shows, and add a short page_warning.

Fixes #1195