### PR TITLE
docs: deduplicate the Apache APISIX integration entry

### DIFF
--- a/content/en/docs/v3.6/integrations.md
+++ b/content/en/docs/v3.6/integrations.md
@@ -170,7 +170,7 @@ The sections below list etcd client libraries by language.
 ## Projects using etcd
 
 - [etcd Raft users](https://github.com/etcd-io/raft/blob/main/README.md#notable-users) - projects using etcd's raft library implementation.
-- [apache/apisix](https://github.com/apache/apisix) - A dynamic, real-time, high-performance API gateway
+- [Apache APISIX](https://github.com/apache/apisix) - An API gateway that uses etcd as its configuration store.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++
 - [binocarlos/yoda](https://github.com/binocarlos/yoda) - etcd + ZeroMQ
 - [blox/blox](https://github.com/blox/blox) - a collection of open source projects for container management and orchestration with AWS ECS
@@ -202,7 +202,6 @@ The sections below list etcd client libraries by language.
 - [Rook](https://github.com/rook/rook) - Storage Orchestration for Kubernetes
 - [Patroni](https://github.com/zalando/patroni) - A template for PostgreSQL High Availability with ZooKeeper, etcd, or Consul
 - [Trillian](https://github.com/google/trillian) - Trillian implements a Merkle tree whose contents are served from a data storage layer, to allow scalability to extremely large trees.
-- [Apache APISIX](https://github.com/apache/apisix) - Apache APISIX is a dynamic, real-time, high-performance API gateway.
 - [purpleidea/mgmt](https://github.com/purpleidea/mgmt) - Next generation distributed, event-driven, parallel config management!
 - [Portworx/kvdb](https://docs.portworx.com/concepts/internal-kvdb/) - The internal kvdb for storing Portworx cluster configuration.
 - [Apache Pulsar](https://pulsar.apache.org/) - Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud.

--- a/content/en/docs/v3.7/integrations.md
+++ b/content/en/docs/v3.7/integrations.md
@@ -169,7 +169,7 @@ The sections below list etcd client libraries by language.
 ## Projects using etcd
 
 - [etcd Raft users](https://github.com/etcd-io/raft/blob/main/README.md#notable-users) - projects using etcd's raft library implementation.
-- [apache/apisix](https://github.com/apache/apisix) - A dynamic, real-time, high-performance API gateway
+- [Apache APISIX](https://github.com/apache/apisix) - An API gateway that uses etcd as its configuration store.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++
 - [binocarlos/yoda](https://github.com/binocarlos/yoda) - etcd + ZeroMQ
 - [blox/blox](https://github.com/blox/blox) - a collection of open source projects for container management and orchestration with AWS ECS
@@ -201,7 +201,6 @@ The sections below list etcd client libraries by language.
 - [Rook](https://github.com/rook/rook) - Storage Orchestration for Kubernetes
 - [Patroni](https://github.com/zalando/patroni) - A template for PostgreSQL High Availability with ZooKeeper, etcd, or Consul
 - [Trillian](https://github.com/google/trillian) - Trillian implements a Merkle tree whose contents are served from a data storage layer, to allow scalability to extremely large trees.
-- [Apache APISIX](https://github.com/apache/apisix) - Apache APISIX is a dynamic, real-time, high-performance API gateway.
 - [purpleidea/mgmt](https://github.com/purpleidea/mgmt) - Next generation distributed, event-driven, parallel config management!
 - [Portworx/kvdb](https://docs.portworx.com/concepts/internal-kvdb/) - The internal kvdb for storing Portworx cluster configuration.
 - [Apache Pulsar](https://pulsar.apache.org/) - Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud.

--- a/content/en/docs/v3.8/integrations.md
+++ b/content/en/docs/v3.8/integrations.md
@@ -169,7 +169,7 @@ The sections below list etcd client libraries by language.
 ## Projects using etcd
 
 - [etcd Raft users](https://github.com/etcd-io/raft/blob/main/README.md#notable-users) - projects using etcd's raft library implementation.
-- [apache/apisix](https://github.com/apache/apisix) - A dynamic, real-time, high-performance API gateway
+- [Apache APISIX](https://github.com/apache/apisix) - An API gateway that uses etcd as its configuration store.
 - [apache/celix](https://github.com/apache/celix) - an implementation of the OSGi specification adapted to C and C++
 - [binocarlos/yoda](https://github.com/binocarlos/yoda) - etcd + ZeroMQ
 - [blox/blox](https://github.com/blox/blox) - a collection of open source projects for container management and orchestration with AWS ECS
@@ -201,7 +201,6 @@ The sections below list etcd client libraries by language.
 - [Rook](https://github.com/rook/rook) - Storage Orchestration for Kubernetes
 - [Patroni](https://github.com/zalando/patroni) - A template for PostgreSQL High Availability with ZooKeeper, etcd, or Consul
 - [Trillian](https://github.com/google/trillian) - Trillian implements a Merkle tree whose contents are served from a data storage layer, to allow scalability to extremely large trees.
-- [Apache APISIX](https://github.com/apache/apisix) - Apache APISIX is a dynamic, real-time, high-performance API gateway.
 - [purpleidea/mgmt](https://github.com/purpleidea/mgmt) - Next generation distributed, event-driven, parallel config management!
 - [Portworx/kvdb](https://docs.portworx.com/concepts/internal-kvdb/) - The internal kvdb for storing Portworx cluster configuration.
 - [Apache Pulsar](https://pulsar.apache.org/) - Apache Pulsar is an open-source, distributed messaging and streaming platform built for the cloud.


### PR DESCRIPTION
## What this PR does

- Deduplicates the Apache APISIX entry under `Projects using etcd`.
- Uses the canonical project name and describes the direct relationship to etcd.
- Keeps the v3.6, v3.7, and v3.8 Draft documentation in sync.

The separate `api7/lua-resty-etcd` Lua client entry is unchanged.

## Why

The affected pages currently list Apache APISIX twice with inconsistent names and descriptions. Apache APISIX uses etcd as its configuration store in its etcd-backed deployment modes, so a single factual project entry is sufficient.

## Validation

- A standard `npm install` passed under Node 24 LTS, Bash 5, and Linux arm64.
- `npm run build` passed and generated 915 pages.
- `npm run check-links` passed for 821 documents.
- `make markdown-diff-lint` passed. It reported only two pre-existing `MD034` warnings outside the changed ranges.
- `git diff --check` passed.
- Each affected page contains one Apache APISIX project entry and retains the separate `api7/lua-resty-etcd` client entry.

This PR was written in part with the assistance of generative AI. I reviewed and understand every change.