### PR TITLE
M3 Website Reference adjusted to point to correct URL

### DIFF
--- a/data/used_by.yaml
+++ b/data/used_by.yaml
@@ -19,7 +19,7 @@
     CoreDNS uses etcd as an optional backend
 - name: M3
   # date: 20yy-mm-dd
-  link: https://eng.uber.com/m3/
+  link: https://m3db.io/
   image: /img/m3-logo.png
   quote: >
     M3, a large-scale metrics platform for Prometheus created by Uber, uses etcd for rule storage and other functions


### PR DESCRIPTION
Currently, when a user clicks on the M3 Logo, one will be redirected to the URL
`https://eng.uber.com/m3/`

which seem to no longer exist:

```
<Error>
<Code>NoSuchKey</Code>
<Message>code:not-found message:tpath not found: /prod/eng_uber_com/m3</Message>
<Resource>/prod/eng_uber_com/m3/</Resource>
<RequestId>b398b5a2-732b-47e2-8331-7fbb77468335</RequestId>
</Error>
```

I just noticed it while browsing on the website.. 😄 
So I decided to quickly open up the PR to point to the new URL `https://m3db.io/`
