### PR TITLE
Update old blog posts to link to the security vulnerability reporting form.

### DIFF
--- a/content/en/blog/2026/july-23-patch-release.md
+++ b/content/en/blog/2026/july-23-patch-release.md
@@ -32,7 +32,7 @@ This vulnerability was reported by members of the etcd community. Our SIG is dee
 - [Luis Toro](https://github.com/lobuhi)
 - Anthropic and [Adam Korczynski](https://github.com/AdamKorcz)
 
-If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+If you find a vulnerability in etcd, please report it [through the form on GitHub](https://github.com/etcd-io/etcd/security/advisories/new).
 
 ## Security Fix: `tlsListener.acceptLoop` spawns unbounded handshake goroutines with no deadline
 

--- a/content/en/blog/2026/july-patch-release.md
+++ b/content/en/blog/2026/july-patch-release.md
@@ -22,7 +22,7 @@ This release updates v3.5 and v3.6 to [golang v1.25.11](https://groups.google.co
 
 It is unknown how many of these vulnerabilities are exploitable in etcd, but users should plan to apply the patch as soon as convenient regardless.
 
-If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+If you find a vulnerability in etcd, please report it [through the form on GitHub](https://github.com/etcd-io/etcd/security/advisories/new).
 
 ## Fixing websocket authentication with bearer-prefixed tokens
 

--- a/content/en/blog/2026/june-patch-release.md
+++ b/content/en/blog/2026/june-patch-release.md
@@ -27,6 +27,6 @@ So say goodbye to v3.4, and prepare your upgrade scripts now.
 
 This release updates v3.4, v3.5 and v3.6 to [golang v1.25.10](https://github.com/etcd-io/etcd/issues/21725), which patches [multiple security vulnerabilities in go](https://groups.google.com/g/golang-nuts/c/QEttt5ZoGrE).  CVEs for patched vulnerabilities include the following: CVE-2026-42501, CVE-2026-39825, CVE-2026-39836, CVE-2026-42499, CVE-2026-39820, CVE-2026-39819, CVE-2026-39817, CVE-2026-33814, CVE-2026-39826, CVE-2026-33811, and CVE-2026-39823.  It is unknown how many of these vulnerabilities are exploitable in etcd, but users should plan to apply the patch as soon as convenient regardless.
 
-If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+If you find a vulnerability in etcd, please report it [through the form on GitHub](https://github.com/etcd-io/etcd/security/advisories/new).
 
 This release also fixes several reliability issues, which can be found in the [changelog](https://github.com/etcd-io/etcd/releases/tag/v3.6.12)

--- a/content/en/blog/2026/mar20-patch-release.md
+++ b/content/en/blog/2026/mar20-patch-release.md
@@ -28,4 +28,4 @@ All of these vulnerabilies were reported by members of the etcd community.  Our 
 * @OLU-DEVX
 * Battulga Byambaa
 
-If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+If you find a vulnerability in etcd, please report it [through the form on GitHub](https://github.com/etcd-io/etcd/security/advisories/new).

--- a/content/en/blog/2026/may-patch-release.md
+++ b/content/en/blog/2026/may-patch-release.md
@@ -34,4 +34,4 @@ This vulnerability was reported by members of the etcd community. Our SIG is dee
 * Samy Ghannad ([@SamyGhannad](https://github.com/SamyGhannad)) for reporting that read access via `PrevKv` in a `Put` request within etcd transactions bypassed RBAC authorization checks.
 * Benjamin Wang ([@ahrtr](https://github.com/ahrtr)) for further analyzing that lease attachment in a `Put` request within etcd transactions also bypassed RBAC authorization checks.
 
-If you find a vulnerability in etcd, please report it to [our security team](mailto:security@etcd.io).
+If you find a vulnerability in etcd, please report it [through the form on GitHub](https://github.com/etcd-io/etcd/security/advisories/new).


### PR DESCRIPTION
Per change in security reporting process.