### PR TITLE
Consistently order upgrade and downgrade pages by descending version

### DIFF
--- a/content/en/docs/v3.6/downgrades/downgrade_3_5.md
+++ b/content/en/docs/v3.6/downgrades/downgrade_3_5.md
@@ -1,6 +1,6 @@
 ---
 title: Downgrade etcd from 3.5 to 3.4
-weight: 6650
+weight: 6700
 description: Processes, checklists, and notes on downgrading etcd from 3.5 to 3.4
 ---
 

--- a/content/en/docs/v3.7/downgrades/downgrade_3_5.md
+++ b/content/en/docs/v3.7/downgrades/downgrade_3_5.md
@@ -1,6 +1,6 @@
 ---
 title: Downgrade etcd from 3.5 to 3.4
-weight: 6650
+weight: 6700
 description: Processes, checklists, and notes on downgrading etcd from 3.5 to 3.4
 ---
 

--- a/content/en/docs/v3.7/upgrades/upgrade_3_7.md
+++ b/content/en/docs/v3.7/upgrades/upgrade_3_7.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade etcd from v3.6 to v3.7
-weight: 6700
+weight: 6550
 description: Processes, checklists, and notes on upgrading etcd from v3.6 to v3.7
 ---
 

--- a/content/en/docs/v3.8/downgrades/downgrade_3_5.md
+++ b/content/en/docs/v3.8/downgrades/downgrade_3_5.md
@@ -1,6 +1,6 @@
 ---
 title: Downgrade etcd from 3.5 to 3.4
-weight: 6650
+weight: 6700
 description: Processes, checklists, and notes on downgrading etcd from 3.5 to 3.4
 ---
 

--- a/content/en/docs/v3.8/upgrades/upgrade_3_7.md
+++ b/content/en/docs/v3.8/upgrades/upgrade_3_7.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade etcd from v3.6 to v3.7
-weight: 6700
+weight: 6550
 description: Processes, checklists, and notes on upgrading etcd from v3.6 to v3.7
 ---
 


### PR DESCRIPTION
Resolves #1218

The weights have been changed in v3.8, v3.7, and v3.6 [Downgrading](https://etcd.io/docs/v3.7/downgrades/) and [Upgrading](https://etcd.io/docs/v3.7/upgrades/) sections so that the versions are in descending order.

v3.8 Downgrading before:
<img width="606" height="515" alt="image" src="https://github.com/user-attachments/assets/be19be70-9207-4cf4-a3b6-86e7450f070b" />

v3.8 Downgrading after:
<img width="580" height="510" alt="image" src="https://github.com/user-attachments/assets/67019ce1-d61e-4c14-8e39-b197674ec141" />

v3.7 Downgrading before:
<img width="567" height="516" alt="image" src="https://github.com/user-attachments/assets/d1b9ee2e-8730-4e92-b290-e90f67334315" />

v3.7 Downgrading after:
<img width="567" height="522" alt="image" src="https://github.com/user-attachments/assets/fb96cf61-37cf-4ddb-afc9-4d161f89e821" />

v3.6 Downgrading before:
<img width="580" height="420" alt="image" src="https://github.com/user-attachments/assets/a394759b-9f4a-4b59-bb76-74448b019769" />

v3.6 Downgrading after:
<img width="565" height="432" alt="image" src="https://github.com/user-attachments/assets/2cdb049d-8e0a-437c-95de-704d1385892a" />

v3.8 Upgrading before:
<img width="539" height="682" alt="image" src="https://github.com/user-attachments/assets/5448b15f-90d3-4cfe-933a-a975ab9a93f0" />

v3.8 Upgrading after:
<img width="537" height="678" alt="image" src="https://github.com/user-attachments/assets/208561ef-338b-4206-a17f-51b09745681b" />

v3.7 Upgrading before:
<img width="543" height="685" alt="image" src="https://github.com/user-attachments/assets/56d77691-b291-40d2-9f24-a752504ab371" />

v3.7 Upgrading after:
<img width="530" height="681" alt="image" src="https://github.com/user-attachments/assets/001533bf-f970-4336-bf8c-c7c70bb6dfa5" />